### PR TITLE
fix: remove unsupported TypeScript option

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -19,7 +19,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -17,7 +17,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary
- remove deprecated `erasableSyntaxOnly` option from TypeScript configs

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4240a230832bbf6498e054101533