### PR TITLE
fix: import vitest config for test typing

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- fix TypeScript error by importing `defineConfig` from `vitest/config`

## Testing
- `npm run lint --prefix web`
- `npm test --prefix web`
- `npm run build --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_689d4404dac4832b84e9569b3f3c6a9a