### PR TITLE
Add speech and text vocabulary inputs

### DIFF
--- a/web/src/vocab/SpeechInput.tsx
+++ b/web/src/vocab/SpeechInput.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import useVocabAnswer from './useVocabAnswer'
+import TextInput from './TextInput'
+
+const SpeechInput = () => {
+  const { setAnswer } = useVocabAnswer()
+  const recognitionRef = useRef<any>(null)
+  const [supported, setSupported] = useState(true)
+
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition
+
+    if (!SpeechRecognition) {
+      setSupported(false)
+      return
+    }
+
+    const recognition = new SpeechRecognition()
+    recognition.lang = 'en-US'
+    recognition.interimResults = false
+    recognition.maxAlternatives = 1
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript = event.results[0][0].transcript
+      setAnswer(transcript)
+    }
+
+    recognitionRef.current = recognition
+
+    return () => {
+      recognition.stop()
+    }
+  }, [setAnswer])
+
+  const start = () => {
+    recognitionRef.current?.start()
+  }
+
+  if (!supported) {
+    return <TextInput />
+  }
+
+  return (
+    <button type="button" onClick={start}>
+      Speak
+    </button>
+  )
+}
+
+export default SpeechInput

--- a/web/src/vocab/TextInput.tsx
+++ b/web/src/vocab/TextInput.tsx
@@ -1,0 +1,14 @@
+import { ChangeEvent } from 'react'
+import useVocabAnswer from './useVocabAnswer'
+
+const TextInput = () => {
+  const { answer, setAnswer } = useVocabAnswer()
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setAnswer(e.target.value)
+  }
+
+  return <input type="text" value={answer} onChange={handleChange} />
+}
+
+export default TextInput

--- a/web/src/vocab/useVocabAnswer.ts
+++ b/web/src/vocab/useVocabAnswer.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand'
+
+type VocabState = {
+  answer: string
+  setAnswer: (answer: string) => void
+}
+
+const useVocabStore = create<VocabState>((set) => ({
+  answer: '',
+  setAnswer: (answer) => set({ answer }),
+}))
+
+const useVocabAnswer = () => {
+  const answer = useVocabStore((s) => s.answer)
+  const setAnswer = useVocabStore((s) => s.setAnswer)
+
+  const isCorrect = (expected: string) => {
+    return answer.trim().toLowerCase() === expected.trim().toLowerCase()
+  }
+
+  return { answer, setAnswer, isCorrect }
+}
+
+export default useVocabAnswer
+export { useVocabStore }

--- a/web/src/vocab/vocab.test.tsx
+++ b/web/src/vocab/vocab.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, act, render, fireEvent, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import useVocabAnswer, { useVocabStore } from './useVocabAnswer'
+import SpeechInput from './SpeechInput'
+import TextInput from './TextInput'
+
+afterEach(() => {
+  cleanup()
+  useVocabStore.setState({ answer: '' })
+})
+
+describe('useVocabAnswer', () => {
+  it('tracks answer and correctness', () => {
+    const { result } = renderHook(() => useVocabAnswer())
+
+    act(() => result.current.setAnswer('apple'))
+
+    expect(result.current.answer).toBe('apple')
+    expect(result.current.isCorrect('Apple')).toBe(true)
+    expect(result.current.isCorrect('banana')).toBe(false)
+  })
+})
+
+describe('SpeechInput', () => {
+  it('falls back to TextInput when unsupported', () => {
+    const original = (window as any).SpeechRecognition
+    ;(window as any).SpeechRecognition = undefined
+
+    const { container } = render(<SpeechInput />)
+    expect(container.querySelector('input')).not.toBeNull()
+
+    ;(window as any).SpeechRecognition = original
+  })
+})
+
+describe('TextInput', () => {
+  it('updates answer in store', () => {
+    const { getByRole } = render(<TextInput />)
+    const input = getByRole('textbox') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'cat' } })
+
+    const { result } = renderHook(() => useVocabAnswer())
+    expect(result.current.answer).toBe('cat')
+  })
+})


### PR DESCRIPTION
## Summary
- add SpeechInput using Web Speech API with fallback to TextInput
- expose global answer via useVocabAnswer hook
- test vocab input components and correctness logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d49e82d50832bb4e7012cabb1bf88