### PR TITLE
Add level manager with boss and door puzzle levels

### DIFF
--- a/web/src/game/LevelManager.test.tsx
+++ b/web/src/game/LevelManager.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it } from 'vitest'
+import LevelManager, { LevelComponent } from './LevelManager'
+
+const LevelA: LevelComponent = ({ onComplete }) => (
+  <button onClick={onComplete}>LevelA</button>
+)
+const LevelB: LevelComponent = () => <div>LevelB</div>
+
+describe('LevelManager', () => {
+  it('progresses through levels', () => {
+    render(<LevelManager levels={[LevelA, LevelB]} />)
+    expect(screen.getByText('LevelA')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('LevelA'))
+    expect(screen.getByText('LevelB')).toBeInTheDocument()
+  })
+})
+

--- a/web/src/game/LevelManager.tsx
+++ b/web/src/game/LevelManager.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+
+export type LevelComponent = React.ComponentType<{ onComplete: () => void }>
+
+interface LevelManagerProps {
+  levels: LevelComponent[]
+}
+
+const LevelManager = ({ levels }: LevelManagerProps) => {
+  const [index, setIndex] = useState(0)
+  const CurrentLevel = levels[index]
+
+  const handleComplete = () => {
+    setIndex((i) => Math.min(i + 1, levels.length - 1))
+  }
+
+  return <CurrentLevel onComplete={handleComplete} />
+}
+
+export default LevelManager
+

--- a/web/src/game/levels/BossLevel.test.tsx
+++ b/web/src/game/levels/BossLevel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it, vi } from 'vitest'
+import BossLevel from './BossLevel'
+
+describe('BossLevel', () => {
+  it('subtracts boss HP on correct answers', () => {
+    const onComplete = vi.fn()
+    render(<BossLevel onComplete={onComplete} />)
+
+    const input = screen.getByLabelText('answer')
+    const button = screen.getByRole('button', { name: /attack/i })
+
+    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.click(button)
+    expect(screen.getByText(/Boss HP: 2/)).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.click(button)
+    expect(screen.getByText(/Boss HP: 1/)).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.click(button)
+    expect(onComplete).toHaveBeenCalled()
+  })
+})
+

--- a/web/src/game/levels/BossLevel.tsx
+++ b/web/src/game/levels/BossLevel.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+
+interface BossLevelProps {
+  onComplete: () => void
+}
+
+const BossLevel = ({ onComplete }: BossLevelProps) => {
+  const [bossHp, setBossHp] = useState(3)
+  const [answer, setAnswer] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (answer.trim().toLowerCase() === 'correct') {
+      const next = bossHp - 1
+      setBossHp(next)
+      if (next <= 0) onComplete()
+    }
+    setAnswer('')
+  }
+
+  return (
+    <div>
+      <p>Boss HP: {bossHp}</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          aria-label="answer"
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+        />
+        <button type="submit">Attack</button>
+      </form>
+    </div>
+  )
+}
+
+export default BossLevel
+

--- a/web/src/game/levels/DoorPuzzleLevel.test.tsx
+++ b/web/src/game/levels/DoorPuzzleLevel.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import DoorPuzzleLevel from './DoorPuzzleLevel'
+
+describe('DoorPuzzleLevel', () => {
+  it('unlocks when tools match words', () => {
+    const onComplete = vi.fn()
+    render(<DoorPuzzleLevel onComplete={onComplete} />)
+
+    fireEvent.change(screen.getByLabelText('lock'), { target: { value: 'key' } })
+    expect(onComplete).not.toHaveBeenCalled()
+    fireEvent.change(screen.getByLabelText('nail'), { target: { value: 'hammer' } })
+    expect(onComplete).toHaveBeenCalled()
+  })
+})
+

--- a/web/src/game/levels/DoorPuzzleLevel.tsx
+++ b/web/src/game/levels/DoorPuzzleLevel.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+interface DoorPuzzleLevelProps {
+  onComplete: () => void
+}
+
+const pairs: Record<string, string> = {
+  key: 'lock',
+  hammer: 'nail',
+}
+
+const DoorPuzzleLevel = ({ onComplete }: DoorPuzzleLevelProps) => {
+  const [choices, setChoices] = useState<Record<string, string>>({})
+
+  const handleChange = (word: string, tool: string) => {
+    const newChoices = { ...choices, [word]: tool }
+    setChoices(newChoices)
+    const solved = Object.entries(pairs).every(
+      ([toolName, wordName]) => newChoices[wordName] === toolName
+    )
+    if (solved) onComplete()
+  }
+
+  const words = Object.values(pairs)
+  const tools = Object.keys(pairs)
+
+  return (
+    <div>
+      {words.map((word) => (
+        <div key={word}>
+          <span>{word}</span>
+          <select
+            aria-label={word}
+            value={choices[word] || ''}
+            onChange={(e) => handleChange(word, e.target.value)}
+          >
+            <option value="">Select</option>
+            {tools.map((tool) => (
+              <option key={tool} value={tool}>
+                {tool}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default DoorPuzzleLevel
+


### PR DESCRIPTION
## Summary
- add LevelManager to progress through a list of levels
- create BossLevel that reduces boss HP when answers are correct
- create DoorPuzzleLevel where matching tools to words unlocks the door

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4e3e7824832bb6e7ab3af086508e