### PR TITLE
Add pastel theme, sprite animations, and game screens

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>EchoQuest</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import Game from './game/Game'
+import StartScreen from './screens/StartScreen'
+import VictoryScreen from './screens/VictoryScreen'
+import DefeatScreen from './screens/DefeatScreen'
+
+type Screen = 'start' | 'playing' | 'victory' | 'defeat'
+
+const App = () => {
+  const [screen, setScreen] = useState<Screen>('start')
+
+  const startGame = () => setScreen('playing')
+  const handleWin = () => setScreen('victory')
+  const handleLose = () => setScreen('defeat')
+  const restart = () => setScreen('start')
+
+  switch (screen) {
+    case 'start':
+      return <StartScreen onStart={startGame} />
+    case 'playing':
+      return <Game onWin={handleWin} onLose={handleLose} />
+    case 'victory':
+      return <VictoryScreen onRestart={restart} />
+    case 'defeat':
+      return <DefeatScreen onRestart={restart} />
+    default:
+      return null
+  }
+}
+
+export default App

--- a/web/src/game/Game.tsx
+++ b/web/src/game/Game.tsx
@@ -1,6 +1,11 @@
 import { useRef, useEffect } from 'react'
 
-const Game = () => {
+interface GameProps {
+  onWin?: () => void
+  onLose?: () => void
+}
+
+const Game = ({ onWin = () => {}, onLose = () => {} }: GameProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -27,7 +32,34 @@ const Game = () => {
     return () => cancelAnimationFrame(frameId)
   }, [])
 
-  return <canvas ref={canvasRef} width={800} height={600} />
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex gap-4">
+        <div className="sprite sprite-hero" />
+        <div className="sprite sprite-monster" />
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={800}
+        height={600}
+        className="border border-pastelPurple"
+      />
+      <div className="flex gap-2">
+        <button
+          className="px-2 py-1 rounded bg-pastelGreen text-gray-700"
+          onClick={onWin}
+        >
+          Win
+        </button>
+        <button
+          className="px-2 py-1 rounded bg-pastelYellow text-gray-700"
+          onClick={onLose}
+        >
+          Lose
+        </button>
+      </div>
+    </div>
+  )
 }
 
 export default Game

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2,71 +2,31 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+@layer base {
+  body {
+    @apply m-0 bg-pastelYellow text-gray-800 font-playful;
   }
-  a:hover {
-    color: #747bff;
+}
+
+@layer components {
+  .sprite {
+    @apply w-8 h-8 border border-pastelPurple bg-no-repeat animate-spriteWalk;
+    background-size: 96px 32px;
   }
-  button {
-    background-color: #f9f9f9;
+  .sprite-hero {
+    background-image: linear-gradient(
+      to right,
+      #c8f7c5 0 32px,
+      #c1e1f7 32px 64px,
+      #c8f7c5 64px 96px
+    );
+  }
+  .sprite-monster {
+    background-image: linear-gradient(
+      to right,
+      #ffd1dc 0 32px,
+      #e4c1f9 32px 64px,
+      #ffd1dc 64px 96px
+    );
   }
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,14 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import Game from './game/Game'
+import App from './App'
 
 const root = document.getElementById('root')
 
 if (root) {
   createRoot(root).render(
     <StrictMode>
-      <Game />
+      <App />
     </StrictMode>,
   )
 } else {

--- a/web/src/screens/DefeatScreen.tsx
+++ b/web/src/screens/DefeatScreen.tsx
@@ -1,0 +1,18 @@
+interface DefeatScreenProps {
+  onRestart: () => void
+}
+
+const DefeatScreen = ({ onRestart }: DefeatScreenProps) => (
+  <div className="flex flex-col items-center justify-center h-screen bg-pastelPink text-center">
+    <div className="sprite sprite-monster mb-4" />
+    <h1 className="text-4xl font-playful text-pastelPurple mb-8">Game Over</h1>
+    <button
+      onClick={onRestart}
+      className="px-4 py-2 bg-pastelBlue text-gray-700 rounded"
+    >
+      Try Again
+    </button>
+  </div>
+)
+
+export default DefeatScreen

--- a/web/src/screens/StartScreen.tsx
+++ b/web/src/screens/StartScreen.tsx
@@ -1,0 +1,18 @@
+interface StartScreenProps {
+  onStart: () => void
+}
+
+const StartScreen = ({ onStart }: StartScreenProps) => (
+  <div className="flex flex-col items-center justify-center h-screen bg-pastelBlue text-center">
+    <div className="sprite sprite-hero mb-4" />
+    <h1 className="text-4xl font-playful text-pastelPurple mb-8">EchoQuest</h1>
+    <button
+      onClick={onStart}
+      className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
+    >
+      Start
+    </button>
+  </div>
+)
+
+export default StartScreen

--- a/web/src/screens/VictoryScreen.tsx
+++ b/web/src/screens/VictoryScreen.tsx
@@ -1,0 +1,18 @@
+interface VictoryScreenProps {
+  onRestart: () => void
+}
+
+const VictoryScreen = ({ onRestart }: VictoryScreenProps) => (
+  <div className="flex flex-col items-center justify-center h-screen bg-pastelGreen text-center">
+    <div className="sprite sprite-hero mb-4" />
+    <h1 className="text-4xl font-playful text-pastelPurple mb-8">Victory!</h1>
+    <button
+      onClick={onRestart}
+      className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
+    >
+      Play Again
+    </button>
+  </div>
+)
+
+export default VictoryScreen

--- a/web/src/vocab/SpeechInput.tsx
+++ b/web/src/vocab/SpeechInput.tsx
@@ -4,20 +4,23 @@ import TextInput from './TextInput'
 
 const SpeechInput = () => {
   const { setAnswer } = useVocabAnswer()
-  const recognitionRef = useRef<any>(null)
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
   const [supported, setSupported] = useState(true)
 
   useEffect(() => {
-    const SpeechRecognition =
-      (window as any).SpeechRecognition ||
-      (window as any).webkitSpeechRecognition
+    const speechWindow = window as typeof window & {
+      webkitSpeechRecognition?: typeof SpeechRecognition
+    }
 
-    if (!SpeechRecognition) {
+    const SpeechRecognitionClass =
+      speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition
+
+    if (!SpeechRecognitionClass) {
       setSupported(false)
       return
     }
 
-    const recognition = new SpeechRecognition()
+    const recognition = new SpeechRecognitionClass()
     recognition.lang = 'en-US'
     recognition.interimResults = false
     recognition.maxAlternatives = 1

--- a/web/src/vocab/vocab.test.tsx
+++ b/web/src/vocab/vocab.test.tsx
@@ -58,13 +58,16 @@ describe('useVocabAnswer', () => {
 
 describe('SpeechInput', () => {
   it('falls back to TextInput when unsupported', () => {
-    const original = (window as any).SpeechRecognition
-    ;(window as any).SpeechRecognition = undefined
+    const speechWindow = window as typeof window & {
+      SpeechRecognition?: unknown
+    }
+    const original = speechWindow.SpeechRecognition
+    speechWindow.SpeechRecognition = undefined
 
     const { container } = render(<SpeechInput />)
     expect(container.querySelector('input')).not.toBeNull()
 
-    ;(window as any).SpeechRecognition = original
+    speechWindow.SpeechRecognition = original
   })
 })
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,8 +1,27 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        pastelPink: '#ffd1dc',
+        pastelBlue: '#c1e1f7',
+        pastelGreen: '#c8f7c5',
+        pastelYellow: '#fff5ba',
+        pastelPurple: '#e4c1f9',
+      },
+      fontFamily: {
+        playful: ['"Comic Neue"', 'cursive'],
+      },
+      keyframes: {
+        spriteWalk: {
+          '100%': { backgroundPosition: '-96px 0' },
+        },
+      },
+      animation: {
+        spriteWalk: 'spriteWalk 1s steps(3) infinite',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind theme with pastel palette, playful font, and sprite animation keyframes
- add animated hero and monster sprites with start, victory, and defeat screens
- wire up App component to handle screen transitions and basic win/lose actions
- replace PNG sprites with CSS gradients to avoid binary assets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d66f0a9c0832b9a4dfa7fc768a6dc