### PR TITLE
Fix build errors and enable npm build/test success

### DIFF
--- a/web/src/game/LevelManager.test.tsx
+++ b/web/src/game/LevelManager.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { describe, expect, it } from 'vitest'
-import LevelManager, { LevelComponent } from './LevelManager'
+import LevelManager, { type LevelComponent } from './LevelManager'
 
 const LevelA: LevelComponent = ({ onComplete }) => (
   <button onClick={onComplete}>LevelA</button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -4,13 +4,20 @@
 
 @layer base {
   body {
-    @apply m-0 bg-pastelYellow text-gray-800 font-playful;
+    margin: 0;
+    background-color: #fff5ba;
+    color: #1f2937;
+    font-family: 'Comic Neue', cursive;
   }
 }
 
 @layer components {
   .sprite {
-    @apply w-8 h-8 border border-pastelPurple bg-no-repeat animate-spriteWalk;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid #e4c1f9;
+    background-repeat: no-repeat;
+    animation: spriteWalk 1s steps(3) infinite;
     background-size: 96px 32px;
   }
   .sprite-hero {

--- a/web/src/vocab/SpeechInput.tsx
+++ b/web/src/vocab/SpeechInput.tsx
@@ -4,12 +4,13 @@ import TextInput from './TextInput'
 
 const SpeechInput = () => {
   const { setAnswer } = useVocabAnswer()
-  const recognitionRef = useRef<SpeechRecognition | null>(null)
+  const recognitionRef = useRef<any>(null)
   const [supported, setSupported] = useState(true)
 
   useEffect(() => {
     const speechWindow = window as typeof window & {
-      webkitSpeechRecognition?: typeof SpeechRecognition
+      SpeechRecognition?: any
+      webkitSpeechRecognition?: any
     }
 
     const SpeechRecognitionClass =
@@ -20,12 +21,12 @@ const SpeechInput = () => {
       return
     }
 
-    const recognition = new SpeechRecognitionClass()
+    const recognition: any = new SpeechRecognitionClass()
     recognition.lang = 'en-US'
     recognition.interimResults = false
     recognition.maxAlternatives = 1
 
-    recognition.onresult = (event: SpeechRecognitionEvent) => {
+    recognition.onresult = (event: any) => {
       const transcript = event.results[0][0].transcript
       setAnswer(transcript)
     }

--- a/web/src/vocab/TextInput.tsx
+++ b/web/src/vocab/TextInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react'
+import type { ChangeEvent } from 'react'
 import useVocabAnswer from './useVocabAnswer'
 
 const TextInput = () => {

--- a/web/src/vocab/useVocabStore.ts
+++ b/web/src/vocab/useVocabStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import loadVocab, { VocabMap } from './vocabLoader'
+import loadVocab, { type VocabMap } from './vocabLoader'
 
 const allVocab: VocabMap = loadVocab()
 const defaultLevel = Object.keys(allVocab)[0] || ''

--- a/web/src/vocab/vocabLoader.ts
+++ b/web/src/vocab/vocabLoader.ts
@@ -1,9 +1,9 @@
 export type VocabMap = Record<string, Record<string, string>>
 
-const files = import.meta.glob<{ default: string }>('/public/vocab/*/*.{png,jpg,webp}', {
+const files = import.meta.glob('/public/vocab/*/*.{png,jpg,webp}', {
   eager: true,
   import: 'default',
-})
+}) as Record<string, string>
 
 export function loadVocab(fileMap: Record<string, string> = files): VocabMap {
   const vocab: VocabMap = {}


### PR DESCRIPTION
## Summary
- Replace missing Web Speech API types with `any` and guard fallbacks
- Use type-only imports and correct `import.meta.glob` typing to satisfy `verbatimModuleSyntax`
- Rewrite Tailwind `@apply` usage in base styles to avoid unknown utility errors

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d47eb12f4832b91bda8145612dfba