### PR TITLE
Integrate vocab-based gameplay and boss combat

### DIFF
--- a/web/src/__tests__/levels.test.tsx
+++ b/web/src/__tests__/levels.test.tsx
@@ -1,26 +1,34 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import BossLevel from '../game/levels/BossLevel'
 import DoorPuzzleLevel from '../game/levels/DoorPuzzleLevel'
+import { useVocabAnswerStore } from '../vocab/useVocabAnswer'
+import useVocabStore from '../vocab/useVocabStore'
+
+afterEach(() => {
+  useVocabAnswerStore.setState({ answer: '' })
+  useVocabStore.setState({ images: {} })
+})
 
 describe('BossLevel', () => {
   it('reduces HP and triggers completion', () => {
     const onComplete = vi.fn()
+    useVocabStore.setState({ images: { apple: '/apple.png' } })
     render(<BossLevel onComplete={onComplete} />)
 
-    const input = screen.getByLabelText('answer')
+    const input = screen.getAllByRole('textbox')[0]
     const attack = screen.getByRole('button', { name: /attack/i })
 
-    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.change(input, { target: { value: 'apple' } })
     fireEvent.click(attack)
     expect(screen.getByText(/Boss HP: 2/)).toBeInTheDocument()
 
-    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.change(input, { target: { value: 'apple' } })
     fireEvent.click(attack)
     expect(screen.getByText(/Boss HP: 1/)).toBeInTheDocument()
 
-    fireEvent.change(input, { target: { value: 'correct' } })
+    fireEvent.change(input, { target: { value: 'apple' } })
     fireEvent.click(attack)
     expect(onComplete).toHaveBeenCalled()
   })

--- a/web/src/__tests__/vocab.test.tsx
+++ b/web/src/__tests__/vocab.test.tsx
@@ -22,7 +22,7 @@ describe('TextInput', () => {
 describe('SpeechInput', () => {
   it('stores transcript when speech recognized', () => {
     class MockSpeechRecognition {
-      public onresult: ((event: any) => void) | null = null
+      public onresult: ((event: { results: Array<Array<{ transcript: string }>> }) => void) | null = null
       lang = ''
       interimResults = false
       maxAlternatives = 1
@@ -31,9 +31,9 @@ describe('SpeechInput', () => {
       }
       stop() {}
     }
-    const speechWindow = window as any
+    const speechWindow = window as Window & { SpeechRecognition?: unknown }
     const original = speechWindow.SpeechRecognition
-    speechWindow.SpeechRecognition = MockSpeechRecognition
+    speechWindow.SpeechRecognition = MockSpeechRecognition as unknown
 
     const { getByRole } = render(<SpeechInput />)
     fireEvent.click(getByRole('button', { name: /speak/i }))

--- a/web/src/game/Game.tsx
+++ b/web/src/game/Game.tsx
@@ -1,63 +1,18 @@
-import { useRef, useEffect } from 'react'
+import type { LevelComponent } from './LevelManager'
+import LevelManager from './LevelManager'
+import DoorPuzzleLevel from './levels/DoorPuzzleLevel'
+import BossLevel from './levels/BossLevel'
 
 interface GameProps {
   onWin?: () => void
-  onLose?: () => void
 }
 
-const Game = ({ onWin = () => {}, onLose = () => {} }: GameProps) => {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-
-  useEffect(() => {
-    let frameId: number
-    const canvas = canvasRef.current
-    let context: CanvasRenderingContext2D | null = null
-
-    try {
-      context = canvas?.getContext('2d') ?? null
-    } catch {
-      context = null
-    }
-
-    const loop = () => {
-      if (!canvas || !context) return
-
-      context.clearRect(0, 0, canvas.width, canvas.height)
-      // Game logic and rendering would go here
-
-      frameId = requestAnimationFrame(loop)
-    }
-
-    frameId = requestAnimationFrame(loop)
-    return () => cancelAnimationFrame(frameId)
-  }, [])
+const Game = ({ onWin = () => {} }: GameProps) => {
+  const levels: LevelComponent[] = [DoorPuzzleLevel, BossLevel]
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="flex gap-4">
-        <div className="sprite sprite-hero" />
-        <div className="sprite sprite-monster" />
-      </div>
-      <canvas
-        ref={canvasRef}
-        width={800}
-        height={600}
-        className="border border-pastelPurple"
-      />
-      <div className="flex gap-2">
-        <button
-          className="px-2 py-1 rounded bg-pastelGreen text-gray-700"
-          onClick={onWin}
-        >
-          Win
-        </button>
-        <button
-          className="px-2 py-1 rounded bg-pastelYellow text-gray-700"
-          onClick={onLose}
-        >
-          Lose
-        </button>
-      </div>
+      <LevelManager levels={levels} onFinish={onWin} />
     </div>
   )
 }

--- a/web/src/game/LevelManager.tsx
+++ b/web/src/game/LevelManager.tsx
@@ -4,14 +4,19 @@ export type LevelComponent = React.ComponentType<{ onComplete: () => void }>
 
 interface LevelManagerProps {
   levels: LevelComponent[]
+  onFinish: () => void
 }
 
-const LevelManager = ({ levels }: LevelManagerProps) => {
+const LevelManager = ({ levels, onFinish }: LevelManagerProps) => {
   const [index, setIndex] = useState(0)
   const CurrentLevel = levels[index]
 
   const handleComplete = () => {
-    setIndex((i) => Math.min(i + 1, levels.length - 1))
+    if (index < levels.length - 1) {
+      setIndex((i) => i + 1)
+    } else {
+      onFinish()
+    }
   }
 
   return <CurrentLevel onComplete={handleComplete} />

--- a/web/src/game/levels/BossLevel.tsx
+++ b/web/src/game/levels/BossLevel.tsx
@@ -1,32 +1,52 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import SpeechInput from '../../vocab/SpeechInput'
+import TextInput from '../../vocab/TextInput'
+import useVocabAnswer from '../../vocab/useVocabAnswer'
+import useVocabStore from '../../vocab/useVocabStore'
 
 interface BossLevelProps {
   onComplete: () => void
 }
 
 const BossLevel = ({ onComplete }: BossLevelProps) => {
+  const { images } = useVocabStore()
+  const words = Object.keys(images)
   const [bossHp, setBossHp] = useState(3)
-  const [answer, setAnswer] = useState('')
+  const [index, setIndex] = useState(0)
+  const { setAnswer, isCorrect } = useVocabAnswer()
+
+  useEffect(() => {
+    setIndex(0)
+    setAnswer('')
+  }, [images, setAnswer])
+
+  const currentWord = words[index] || ''
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (answer.trim().toLowerCase() === 'correct') {
+    if (!currentWord) return
+    if (isCorrect(currentWord)) {
       const next = bossHp - 1
       setBossHp(next)
-      if (next <= 0) onComplete()
+      if (next <= 0) {
+        onComplete()
+        return
+      }
+      setIndex((i) => (i + 1) % words.length)
     }
     setAnswer('')
   }
 
   return (
-    <div>
+    <div className="flex flex-col items-center gap-2">
+      <p>The boss blocks your path! Say the word to attack.</p>
       <p>Boss HP: {bossHp}</p>
-      <form onSubmit={handleSubmit}>
-        <input
-          aria-label="answer"
-          value={answer}
-          onChange={(e) => setAnswer(e.target.value)}
-        />
+      {currentWord && (
+        <img src={images[currentWord]} alt={currentWord} width={100} height={100} />
+      )}
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <SpeechInput />
+        <TextInput />
         <button type="submit">Attack</button>
       </form>
     </div>
@@ -34,4 +54,3 @@ const BossLevel = ({ onComplete }: BossLevelProps) => {
 }
 
 export default BossLevel
-

--- a/web/src/game/levels/DoorPuzzleLevel.tsx
+++ b/web/src/game/levels/DoorPuzzleLevel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import useVocabStore from '../../vocab/useVocabStore'
 
 interface DoorPuzzleLevelProps {
   onComplete: () => void
@@ -10,6 +11,7 @@ const pairs: Record<string, string> = {
 }
 
 const DoorPuzzleLevel = ({ onComplete }: DoorPuzzleLevelProps) => {
+  const { images } = useVocabStore()
   const [choices, setChoices] = useState<Record<string, string>>({})
 
   const handleChange = (word: string, tool: string) => {
@@ -25,10 +27,15 @@ const DoorPuzzleLevel = ({ onComplete }: DoorPuzzleLevelProps) => {
   const tools = Object.keys(pairs)
 
   return (
-    <div>
+    <div className="flex flex-col gap-2">
+      <p>The door is locked. Match each tool to open it.</p>
       {words.map((word) => (
-        <div key={word}>
-          <span>{word}</span>
+        <div key={word} className="flex items-center gap-2">
+          {images[word] ? (
+            <img src={images[word]} alt={word} width={50} height={50} />
+          ) : (
+            <span>{word}</span>
+          )}
           <select
             aria-label={word}
             value={choices[word] || ''}

--- a/web/src/screens/StartScreen.tsx
+++ b/web/src/screens/StartScreen.tsx
@@ -1,18 +1,39 @@
+import useVocabStore, { allVocab } from '../vocab/useVocabStore'
+
 interface StartScreenProps {
   onStart: () => void
 }
 
-const StartScreen = ({ onStart }: StartScreenProps) => (
-  <div className="flex flex-col items-center justify-center h-screen bg-pastelBlue text-center">
-    <div className="sprite sprite-hero mb-4" />
-    <h1 className="text-4xl font-playful text-pastelPurple mb-8">EchoQuest</h1>
-    <button
-      onClick={onStart}
-      className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
-    >
-      Start
-    </button>
-  </div>
-)
+const StartScreen = ({ onStart }: StartScreenProps) => {
+  const { level, setLevel } = useVocabStore()
+  const levels = Object.keys(allVocab)
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-pastelBlue text-center">
+      <div className="sprite sprite-hero mb-4" />
+      <h1 className="text-4xl font-playful text-pastelPurple mb-8">EchoQuest</h1>
+      {levels.length > 0 && (
+        <select
+          aria-label="level"
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+          className="mb-4 px-2 py-1 rounded text-gray-700"
+        >
+          {levels.map((lvl) => (
+            <option key={lvl} value={lvl}>
+              {lvl}
+            </option>
+          ))}
+        </select>
+      )}
+      <button
+        onClick={onStart}
+        className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
+      >
+        Start
+      </button>
+    </div>
+  )
+}
 
 export default StartScreen

--- a/web/src/vocab/SpeechInput.tsx
+++ b/web/src/vocab/SpeechInput.tsx
@@ -2,15 +2,28 @@ import { useEffect, useRef, useState } from 'react'
 import useVocabAnswer from './useVocabAnswer'
 import TextInput from './TextInput'
 
+type RecognitionEvent = {
+  results: Array<Array<{ transcript: string }>>
+}
+
+type Recognition = {
+  lang: string
+  interimResults: boolean
+  maxAlternatives: number
+  onresult: ((event: RecognitionEvent) => void) | null
+  start: () => void
+  stop: () => void
+}
+
 const SpeechInput = () => {
   const { setAnswer } = useVocabAnswer()
-  const recognitionRef = useRef<any>(null)
+  const recognitionRef = useRef<Recognition | null>(null)
   const [supported, setSupported] = useState(true)
 
   useEffect(() => {
     const speechWindow = window as typeof window & {
-      SpeechRecognition?: any
-      webkitSpeechRecognition?: any
+      SpeechRecognition?: new () => Recognition
+      webkitSpeechRecognition?: new () => Recognition
     }
 
     const SpeechRecognitionClass =
@@ -21,12 +34,12 @@ const SpeechInput = () => {
       return
     }
 
-    const recognition: any = new SpeechRecognitionClass()
+    const recognition: Recognition = new SpeechRecognitionClass()
     recognition.lang = 'en-US'
     recognition.interimResults = false
     recognition.maxAlternatives = 1
 
-    recognition.onresult = (event: any) => {
+    recognition.onresult = (event: RecognitionEvent) => {
       const transcript = event.results[0][0].transcript
       setAnswer(transcript)
     }


### PR DESCRIPTION
## Summary
- Add level selection on start screen to load vocabulary images
- Introduce LevelManager with door puzzle and boss fight stages
- Enable boss attacks via voice or text answers using vocab images

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d771aa78c832bb27dd2f2c99a888f