### PR TITLE
Add placeholder onLose prop to Game component

### DIFF
--- a/web/src/game/Game.tsx
+++ b/web/src/game/Game.tsx
@@ -5,9 +5,13 @@ import BossLevel from './levels/BossLevel'
 
 interface GameProps {
   onWin?: () => void
+  onLose?: () => void
 }
 
-const Game = ({ onWin = () => {} }: GameProps) => {
+const Game = ({ onWin = () => {}, onLose = () => {} }: GameProps) => {
+  // `onLose` is accepted for future game scenarios where a player may fail a level.
+  // It is intentionally unused at the moment.
+  void onLose
   const levels: LevelComponent[] = [DoorPuzzleLevel, BossLevel]
 
   return (


### PR DESCRIPTION
## Summary
- allow Game component to accept optional `onLose` handler for future failure scenarios

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d7a7f8298832baba5ae59a3671038