### PR TITLE
feat: add speech recognition hook

### DIFF
--- a/web/src/__tests__/vocab.test.tsx
+++ b/web/src/__tests__/vocab.test.tsx
@@ -36,7 +36,7 @@ describe('SpeechInput', () => {
     speechWindow.SpeechRecognition = MockSpeechRecognition as unknown
 
     const { getByRole } = render(<SpeechInput />)
-    fireEvent.click(getByRole('button', { name: /speak/i }))
+    fireEvent.click(getByRole('button', { name: /listen/i }))
 
     const { result } = renderHook(() => useVocabAnswer())
     expect(result.current.answer).toBe('dog')

--- a/web/src/vocab/SpeechInput.tsx
+++ b/web/src/vocab/SpeechInput.tsx
@@ -1,73 +1,36 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect } from 'react'
 import useVocabAnswer from './useVocabAnswer'
 import TextInput from './TextInput'
-
-type RecognitionEvent = {
-  results: Array<Array<{ transcript: string }>>
-}
-
-type Recognition = {
-  lang: string
-  interimResults: boolean
-  maxAlternatives: number
-  onresult: ((event: RecognitionEvent) => void) | null
-  start: () => void
-  stop: () => void
-}
+import useSpeechRecognition from './useSpeechRecognition'
 
 const SpeechInput = () => {
   const { setAnswer } = useVocabAnswer()
-  const recognitionRef = useRef<Recognition | null>(null)
-  const [supported, setSupported] = useState(true)
+  const speech = useSpeechRecognition()
 
   useEffect(() => {
-    const speechWindow = window as typeof window & {
-      SpeechRecognition?: new () => Recognition
-      webkitSpeechRecognition?: new () => Recognition
+    if (speech.transcript) {
+      setAnswer(speech.transcript)
     }
+  }, [speech.transcript, setAnswer])
 
-    const SpeechRecognitionClass =
-      speechWindow.SpeechRecognition || speechWindow.webkitSpeechRecognition
-
-    if (!SpeechRecognitionClass) {
-      setSupported(false)
-      return
-    }
-
-    const recognition: Recognition = new SpeechRecognitionClass()
-    recognition.lang = 'en-US'
-    recognition.interimResults = false
-    recognition.maxAlternatives = 1
-
-    recognition.onresult = (event: RecognitionEvent) => {
-      const transcript = event.results[0][0].transcript
-      setAnswer(transcript)
-    }
-
-    recognitionRef.current = recognition
-
-    return () => {
-      recognition.stop()
-    }
-  }, [setAnswer])
-
-  const start = () => {
-    recognitionRef.current?.start()
-  }
-
-  if (!supported) {
+  if (!speech.supported) {
     return <TextInput />
   }
 
   return (
-    <button
-      type="button"
-      onClick={start}
-      aria-label="Speak"
-      className="px-3 py-2 rounded-lg bg-pastelPurple text-gray-800 shadow hover:brightness-105 active:brightness-95 transition"
-    >
-      🎤 Speak
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={speech.listening ? speech.stop : speech.start}
+        aria-label={speech.listening ? 'Stop listening' : 'Start listening'}
+        className="px-3 py-2 rounded-lg bg-pastelPurple text-gray-800 shadow hover:brightness-105 active:brightness-95 transition"
+      >
+        {speech.listening ? 'Stop' : 'Listen'}
+      </button>
+      {speech.listening && (
+        <span className="text-sm text-rose-600">Listening...</span>
+      )}
+    </div>
   )
 }
 

--- a/web/src/vocab/useSpeechRecognition.ts
+++ b/web/src/vocab/useSpeechRecognition.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface RecognitionEvent {
+  results: Array<Array<{ transcript: string }>>
+}
+
+interface Recognition {
+  lang: string
+  interimResults: boolean
+  maxAlternatives: number
+  onstart: (() => void) | null
+  onerror: ((e: { error: string }) => void) | null
+  onresult: ((e: RecognitionEvent) => void) | null
+  onend: (() => void) | null
+  start: () => void
+  stop: () => void
+}
+
+interface SpeechRecognitionWindow extends Window {
+  SpeechRecognition?: new () => Recognition
+  webkitSpeechRecognition?: new () => Recognition
+}
+
+export interface SpeechHook {
+  supported: boolean
+  listening: boolean
+  transcript: string
+  error: string | null
+  start: () => void
+  stop: () => void
+  reset: () => void
+}
+
+export default function useSpeechRecognition(): SpeechHook {
+  const [supported, setSupported] = useState(false)
+  const [listening, setListening] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const recRef = useRef<Recognition | null>(null)
+
+  useEffect(() => {
+    const { SpeechRecognition, webkitSpeechRecognition } =
+      window as SpeechRecognitionWindow
+    const ctor = SpeechRecognition || webkitSpeechRecognition
+    setSupported(Boolean(ctor))
+    return () => {
+      if (recRef.current) {
+        try {
+          recRef.current.stop()
+        } catch {
+          /* ignore */
+        }
+        recRef.current = null
+      }
+    }
+  }, [])
+
+  const start = () => {
+    if (!supported || listening) return
+    const { SpeechRecognition, webkitSpeechRecognition } =
+      window as SpeechRecognitionWindow
+    const Ctor = SpeechRecognition || webkitSpeechRecognition
+    if (!Ctor) return
+    const rec = new Ctor()
+    rec.lang = 'en-US'
+    rec.interimResults = false
+    rec.maxAlternatives = 1
+    rec.onstart = () => {
+      setTranscript('')
+      setError(null)
+      setListening(true)
+    }
+    rec.onerror = (e: { error: string }) => {
+      setError(e.error || 'speech_error')
+    }
+    rec.onresult = (e: RecognitionEvent) => {
+      const t = e.results?.[0]?.[0]?.transcript || ''
+      setTranscript(String(t))
+    }
+    rec.onend = () => setListening(false)
+    try {
+      rec.start()
+      recRef.current = rec
+    } catch (e) {
+      setError((e as Error).message || 'speech_start_failed')
+    }
+  }
+
+  const stop = () => {
+    try {
+      recRef.current?.stop()
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const reset = () => setTranscript('')
+
+  return { supported, listening, transcript, error, start, stop, reset }
+}
+


### PR DESCRIPTION
## Summary
- add reusable `useSpeechRecognition` hook for Web Speech API
- wire up `SpeechInput` to toggle listening state and show status
- adjust tests for new listen button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d256e804832b8cbdd937f7a66151