### PR TITLE
feat: add scoring system and vocab normalization

### DIFF
--- a/web/src/__tests__/levels.test.tsx
+++ b/web/src/__tests__/levels.test.tsx
@@ -5,10 +5,12 @@ import BossLevel from '../game/levels/BossLevel'
 import DoorPuzzleLevel from '../game/levels/DoorPuzzleLevel'
 import { useVocabAnswerStore } from '../vocab/useVocabAnswer'
 import useVocabStore from '../vocab/useVocabStore'
+import { useGameStatsStore } from '../game/useGameStats'
 
 afterEach(() => {
   useVocabAnswerStore.setState({ answer: '' })
   useVocabStore.setState({ images: {}, damage: 1, setLevel: () => {} })
+  useGameStatsStore.setState({ score: 0, combo: 0, correct: 0 })
 })
 
 describe('BossLevel', () => {

--- a/web/src/__tests__/stats.test.ts
+++ b/web/src/__tests__/stats.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useGameStatsStore } from '../game/useGameStats'
+
+describe('useGameStats', () => {
+  beforeEach(() => {
+    useGameStatsStore.setState({ score: 0, combo: 0, correct: 0 })
+  })
+
+  it('adds score with combo multiplier', () => {
+    const { addCorrect } = useGameStatsStore.getState()
+    addCorrect(2)
+    addCorrect(2)
+    const { score, combo, correct } = useGameStatsStore.getState()
+    expect(score).toBe(60)
+    expect(combo).toBe(2)
+    expect(correct).toBe(2)
+  })
+
+  it('resets combo', () => {
+    const { addCorrect, resetCombo } = useGameStatsStore.getState()
+    addCorrect(1)
+    resetCombo()
+    const { combo } = useGameStatsStore.getState()
+    expect(combo).toBe(0)
+  })
+})

--- a/web/src/game/Game.tsx
+++ b/web/src/game/Game.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react'
 import type { LevelComponent } from './LevelManager'
 import LevelManager from './LevelManager'
 import DoorPuzzleLevel from './levels/DoorPuzzleLevel'
 import BossLevel from './levels/BossLevel'
+import useGameStats from './useGameStats'
 
 interface GameProps {
   onWin?: () => void
@@ -12,10 +14,19 @@ const Game = ({ onWin = () => {}, onLose = () => {} }: GameProps) => {
   // `onLose` is accepted for future game scenarios where a player may fail a level.
   // It is intentionally unused at the moment.
   void onLose
+  const { score, combo, reset } = useGameStats()
   const levels: LevelComponent[] = [BossLevel, DoorPuzzleLevel]
+
+  useEffect(() => {
+    reset()
+  }, [reset])
 
   return (
     <div className="flex flex-col items-center gap-4">
+      <div className="flex gap-4 text-gray-800">
+        <span>Score: {score}</span>
+        <span>Combo: {combo}</span>
+      </div>
       <LevelManager levels={levels} onFinish={onWin} />
     </div>
   )

--- a/web/src/game/levels/BossLevel.tsx
+++ b/web/src/game/levels/BossLevel.tsx
@@ -3,6 +3,7 @@ import SpeechInput from '../../vocab/SpeechInput'
 import TextInput from '../../vocab/TextInput'
 import useVocabAnswer from '../../vocab/useVocabAnswer'
 import useVocabStore from '../../vocab/useVocabStore'
+import useGameStats from '../useGameStats'
 
 interface BossLevelProps {
   onComplete: () => void
@@ -10,6 +11,7 @@ interface BossLevelProps {
 
 const BossLevel = ({ onComplete }: BossLevelProps) => {
   const { images, damage, setLevel } = useVocabStore()
+  const { addCorrect, resetCombo } = useGameStats()
   const words = useMemo(() => Object.keys(images), [images])
   const [bossHp, setBossHp] = useState(5)
   const [index, setIndex] = useState(0)
@@ -28,6 +30,7 @@ const BossLevel = ({ onComplete }: BossLevelProps) => {
     e.preventDefault()
     if (!currentWord) return
     if (isCorrect(currentWord)) {
+      addCorrect(damage)
       const next = bossHp - damage
       setBossHp(next)
       if (next <= 0) {
@@ -35,6 +38,8 @@ const BossLevel = ({ onComplete }: BossLevelProps) => {
         return
       }
       setIndex((i) => (i + 1) % words.length)
+    } else {
+      resetCombo()
     }
     setAnswer('')
   }

--- a/web/src/game/levels/DoorPuzzleLevel.tsx
+++ b/web/src/game/levels/DoorPuzzleLevel.tsx
@@ -3,14 +3,16 @@ import SpeechInput from '../../vocab/SpeechInput'
 import TextInput from '../../vocab/TextInput'
 import useVocabAnswer from '../../vocab/useVocabAnswer'
 import useVocabStore from '../../vocab/useVocabStore'
+import useGameStats from '../useGameStats'
 
 interface DoorPuzzleLevelProps {
   onComplete: () => void
 }
 
 const DoorPuzzleLevel = ({ onComplete }: DoorPuzzleLevelProps) => {
-  const { images, setLevel } = useVocabStore()
+  const { images, damage, setLevel } = useVocabStore()
   const { setAnswer, isCorrect } = useVocabAnswer()
+  const { addCorrect, resetCombo } = useGameStats()
   const [index, setIndex] = useState(0)
   const [silentMode, setSilentMode] = useState(false)
 
@@ -27,12 +29,15 @@ const DoorPuzzleLevel = ({ onComplete }: DoorPuzzleLevelProps) => {
     e.preventDefault()
     if (!current) return
     if (isCorrect(current)) {
+      addCorrect(damage)
       const next = index + 1
       if (next >= tools.length) {
         onComplete()
       } else {
         setIndex(next)
       }
+    } else {
+      resetCombo()
     }
     setAnswer('')
   }

--- a/web/src/game/useGameStats.ts
+++ b/web/src/game/useGameStats.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand'
+
+export type GameStatsState = {
+  score: number
+  combo: number
+  correct: number
+  addCorrect: (difficulty: number) => void
+  reset: () => void
+  resetCombo: () => void
+}
+
+const useGameStatsStore = create<GameStatsState>((set) => ({
+  score: 0,
+  combo: 0,
+  correct: 0,
+  addCorrect: (difficulty) =>
+    set((s) => ({
+      score: s.score + difficulty * 10 * (s.combo + 1),
+      combo: s.combo + 1,
+      correct: s.correct + 1,
+    })),
+  reset: () => set({ score: 0, combo: 0, correct: 0 }),
+  resetCombo: () => set({ combo: 0 }),
+}))
+
+const useGameStats = () => {
+  const score = useGameStatsStore((s) => s.score)
+  const combo = useGameStatsStore((s) => s.combo)
+  const correct = useGameStatsStore((s) => s.correct)
+  const addCorrect = useGameStatsStore((s) => s.addCorrect)
+  const reset = useGameStatsStore((s) => s.reset)
+  const resetCombo = useGameStatsStore((s) => s.resetCombo)
+  return { score, combo, correct, addCorrect, reset, resetCombo }
+}
+
+export default useGameStats
+export { useGameStatsStore }

--- a/web/src/screens/VictoryScreen.tsx
+++ b/web/src/screens/VictoryScreen.tsx
@@ -1,18 +1,25 @@
+import useGameStats from '../game/useGameStats'
+
 interface VictoryScreenProps {
   onRestart: () => void
 }
 
-const VictoryScreen = ({ onRestart }: VictoryScreenProps) => (
-  <div className="flex flex-col items-center justify-center h-screen bg-pastelGreen text-center">
-    <div className="sprite sprite-hero mb-4" />
-    <h1 className="text-4xl font-playful text-pastelPurple mb-8">Victory!</h1>
-    <button
-      onClick={onRestart}
-      className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
-    >
-      Play Again
-    </button>
-  </div>
-)
+const VictoryScreen = ({ onRestart }: VictoryScreenProps) => {
+  const { score, correct } = useGameStats()
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-pastelGreen text-center">
+      <div className="sprite sprite-hero mb-4" />
+      <h1 className="text-4xl font-playful text-pastelPurple mb-4">Victory!</h1>
+      <p className="mb-2 text-gray-800">Score: {score}</p>
+      <p className="mb-8 text-gray-800">Correct Words: {correct}</p>
+      <button
+        onClick={onRestart}
+        className="px-4 py-2 bg-pastelPink text-gray-700 rounded"
+      >
+        Play Again
+      </button>
+    </div>
+  )
+}
 
 export default VictoryScreen

--- a/web/src/vocab/vocabLoader.ts
+++ b/web/src/vocab/vocabLoader.ts
@@ -10,6 +10,15 @@ const files = import.meta.glob('/src/assets/vocab/*/*.{svg,webp,png,jpg}', {
 
 const EXT_PRIORITY = ['svg', 'webp', 'png', 'jpg'] as const
 
+function normalizeWord(word: string): string {
+  return word.toLowerCase().replace(/[^a-z]/g, '')
+}
+
+function fileNameToWord(name: string): string {
+  const base = name.replace(/\.[^.]+$/, '')
+  return normalizeWord(base)
+}
+
 export function loadVocab(fileMap: Record<string, string> = files): VocabData {
   const byFolderWord: Record<string, Record<string, Record<string, string>>> = {}
 
@@ -17,7 +26,8 @@ export function loadVocab(fileMap: Record<string, string> = files): VocabData {
     const match = path.match(/\/vocab\/([^/]+)\/([^/.]+)\.(svg|webp|png|jpg)$/)
     if (!match) continue
     const folder = match[1]
-    const word = match[2]
+    const fileName = match[2]
+    const word = fileNameToWord(fileName)
     const ext = match[3]
     byFolderWord[folder] ||= {}
     byFolderWord[folder][word] ||= {}
@@ -26,8 +36,8 @@ export function loadVocab(fileMap: Record<string, string> = files): VocabData {
 
   const levels: Record<string, LevelData> = {}
   for (const [folder, wordsMap] of Object.entries(byFolderWord)) {
-    const levelMatch = folder.match(/^(\d+)-(.+)$/)
-    const difficulty = levelMatch ? parseInt(levelMatch[1], 10) : 1
+    const levelMatch = folder.match(/^(\d+)-/)
+    const difficulty = levelMatch ? Math.max(1, Math.min(5, parseInt(levelMatch[1], 10))) : 1
     const words: Record<string, string> = {}
 
     for (const [word, extMap] of Object.entries(wordsMap)) {


### PR DESCRIPTION
## Summary
- add Zustand store for score, combo, and correct answers
- show score HUD and update victory screen
- normalize vocab file names and clamp difficulty from folder prefix

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19599a848832bb9b3387cb7172fb0