### PR TITLE
fix: allow lucide-react module resolution

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolvePackageJsonExports": false,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- tweak tsconfig to resolve packages lacking explicit exports

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a19c038b34832b917e4660956259b6