### PR TITLE
The build process was only bundling the JavaScript application code b…

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,2 @@
+/dist
+node_modules

--- a/web/copy-html.js
+++ b/web/copy-html.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, 'dist');
+const publicDir = __dirname; // In our case, public/index.html is at the same level as this script. Let's adjust if needed.
+const srcHtml = path.join(publicDir, 'public', 'index.html');
+const destHtml = path.join(distDir, 'index.html');
+
+// Create dist directory if it doesn't exist
+if (!fs.existsSync(distDir)) {
+  fs.mkdirSync(distDir, { recursive: true });
+}
+
+// Copy index.html
+fs.copyFileSync(srcHtml, destHtml);
+
+console.log('Copied index.html to dist/index.html');

--- a/web/package.json
+++ b/web/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "esbuild index.tsx --bundle --sourcemap --outfile=dist/index.js --servedir=dist --watch",
+    "start": "node copy-html.js && esbuild index.tsx --bundle --sourcemap --outfile=dist/index.js --servedir=dist --watch",
     "test": "echo 'no tests specified'",
-    "build": "tsc --noEmit && esbuild index.tsx --bundle --minify --sourcemap --outfile=dist/index.js"
+    "build": "tsc --noEmit && node copy-html.js && esbuild index.tsx --bundle --minify --sourcemap --outfile=dist/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.294.0",


### PR DESCRIPTION
…ut was not copying the main `public/index.html` file into the final `dist` directory. This caused the development server to show a directory listing instead of the application.

This change introduces a Node.js script (`copy-html.js`) to handle copying the `index.html` file. The `build` and `start` scripts in `package.json` are updated to run this copy script before the bundling step.

Additionally, a `.gitignore` file is added to the `web` directory to prevent the `dist` build output and `node_modules` from being committed to the repository.