### PR TITLE
chore: Add clean script to package.json

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node copy-html.js && esbuild index.tsx --bundle --sourcemap --outfile=dist/index.js --servedir=dist --watch",
     "test": "echo 'no tests specified'",
-    "build": "tsc --noEmit && node copy-html.js && esbuild index.tsx --bundle --minify --sourcemap --outfile=dist/index.js"
+    "build": "tsc --noEmit && node copy-html.js && esbuild index.tsx --bundle --minify --sourcemap --outfile=dist/index.js",
+    "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
     "lucide-react": "^0.294.0",


### PR DESCRIPTION
Adds a `clean` script to `web/package.json` to facilitate a clean build environment. The script removes the `dist` and `node_modules` directories.

This helps in resolving potential local environment issues by providing a standardized way to clear build artifacts and dependencies before running the application.