### PR TITLE
ci: Add npm run test to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install dependencies
         run: npm install --prefix web
+      - name: Test
+        run: npm run test --prefix web
       - name: Build
         run: npm run build --prefix web
       - name: Copy index.html


### PR DESCRIPTION
This change integrates the newly created test suite into the GitHub Actions deployment workflow.

The `npm run test --prefix web` command is now run after dependencies are installed and before the application is built. This ensures that all tests must pass before any new code is deployed to GitHub Pages, improving the overall quality and stability of the main branch.