### PR TITLE
Add pull request CI validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@
 name: Deploy static content to Pages
 
 on:
+  pull_request:
+    branches: ['main']
+
   # Runs on pushes targeting the default branch
   push:
     branches: ['main']
@@ -9,24 +12,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,9 +28,39 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
       - name: Install dependencies
-        run: npm install --prefix web
+        run: npm ci --prefix web
       - name: Test
-        run: npm run test --prefix web
+        run: npm run test --prefix web -- --runInBand
+      - name: Build
+        run: npm run build --prefix web
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: validate
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix web
       - name: Build
         run: npm run build --prefix web
       - name: Copy index.html


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger for PRs targeting `main`.
- Splits the workflow into a `validate` job that runs `npm ci`, tests, and build for PRs/pushes/manual runs.
- Keeps GitHub Pages deployment gated to non-PR events after validation passes.

## Tests
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

Closes #48.