### PR TITLE
Refactor game foundation

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
-import { Level } from './data/levels';
-import { VocabItem } from './components/VocabManager';
+import type { Level } from './data/levels';
+import type { VocabItem } from './types/vocab';
 
 class MockSpeechRecognition {
   static instances: MockSpeechRecognition[] = [];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useRef, useReducer } from 'react';
 import { Sword, Shield, Heart, Lock, Key, Mic, MicOff, Volume2, Star, Zap, Trophy, Skull, Sparkles, Settings, HelpCircle, SkipForward, Globe } from 'lucide-react';
-import { VocabManager, VocabItem } from './components/VocabManager';
+import { VocabManager } from './components/VocabManager';
+import type { VocabItem } from './types/vocab';
 import { initialVocab as defaultInitialVocab } from './data/vocab';
 import { useSpeechRecognition } from './hooks/useSpeechRecognition';
-import { Level, defaultLevels } from './data/levels';
+import { defaultLevels, type Level } from './data/levels';
+import { calculateBossReward, getAvailableWords, isAnswerCorrect, isLevelComplete } from './game/gameLogic';
+import { createInitialState, gameReducer } from './game/gameReducer';
 
 
 // LocalStorage Utilities
@@ -32,171 +35,16 @@ function saveLangToStorage(lang: string) {
     localStorage.setItem(STORAGE_KEY_LANG, lang);
 }
 
-// --- State and Reducer ---
-
-type GameState = 'menu' | 'playing' | 'victory' | 'vocab_management';
-
-interface AppState {
-  vocab: VocabItem[];
-  levels: Level[];
-  currentLevel: number;
-  currentWord: VocabItem | null;
-  userInput: string;
-  score: number;
-  enemyLives: number;
-  collectedTools: string[];
-  message: string;
-  practiceMode: 'voice' | 'spelling';
-  gameState: GameState;
-  correctAnswers: number;
-  showEffect: boolean;
-  combo: number;
-  showHint: boolean;
-  isBossShaking: boolean;
-  recognitionLang: string;
-}
-
-type AppAction =
-  | { type: 'SET_VOCAB'; payload: VocabItem[] }
-  | { type: 'SET_LEVELS'; payload: Level[] }
-  | { type: 'START_GAME' }
-  | { type: 'SET_GAME_STATE'; payload: GameState }
-  | { type: 'SELECT_NEW_WORD'; payload: VocabItem | null }
-  | { type: 'SUBMIT_ANSWER'; payload: { isCorrect: boolean; submittedText: string } }
-  | { type: 'HANDLE_CORRECT_ANSWER'; payload: { points: number; damage: number; word: string } }
-  | { type: 'HANDLE_PUZZLE_CORRECT'; payload: { word: string } }
-  | { type: 'HANDLE_INCORRECT_ANSWER' }
-  | { type: 'NEXT_LEVEL'; payload?: { from: 'puzzle' | 'boss' } }
-  | { type: 'SET_USER_INPUT'; payload: string }
-  | { type: 'SET_MESSAGE'; payload: string }
-  | { type: 'TOGGLE_PRACTICE_MODE' }
-  | { type: 'SET_PRACTICE_MODE'; payload: AppState['practiceMode'] }
-  | { type: 'SET_SHOW_HINT'; payload: boolean }
-  | { type: 'SET_RECOGNITION_LANG'; payload: string }
-  | { type: 'SKIP_WORD' }
-  | { type: 'SET_COMBO'; payload: number }
-  | { type: 'RESET_EFFECTS' };
-
-const POINTS_PER_PUZZLE = 10;
-const BASE_POINTS_PER_WORD = 10;
-
-const initialState: AppState = {
-    vocab: [],
-    levels: defaultLevels,
-    currentLevel: 0,
-    currentWord: null,
-    userInput: '',
-    score: 0,
-    enemyLives: 5,
-    collectedTools: [],
-    message: '',
-    practiceMode: 'voice',
-    gameState: 'menu',
-    correctAnswers: 0,
-    showEffect: false,
-    combo: 0,
-    showHint: false,
-    isBossShaking: false,
-    recognitionLang: loadLangFromStorage(),
-};
-
-function appReducer(state: AppState, action: AppAction): AppState {
-  switch (action.type) {
-    case 'SET_VOCAB':
-      return { ...state, vocab: action.payload };
-    case 'SET_LEVELS':
-        return { ...state, levels: action.payload };
-    case 'START_GAME':
-      return {
-        ...state,
-        gameState: 'playing',
-        currentLevel: 0,
-        score: 0,
-        enemyLives: state.levels[0]?.enemyLives || 5,
-        collectedTools: [],
-        correctAnswers: 0,
-        combo: 0,
-        message: '',
-      };
-    case 'SET_GAME_STATE':
-        return { ...state, gameState: action.payload, message: action.payload === 'menu' ? '請先到字彙管理新增單字!' : '' };
-    case 'SELECT_NEW_WORD':
-        return { ...state, currentWord: action.payload, userInput: '' };
-    case 'HANDLE_CORRECT_ANSWER':
-        const { points, damage, word } = action.payload;
-        const newEnemyLives = state.enemyLives - damage;
-        return {
-            ...state,
-            score: state.score + points,
-            combo: state.combo + 1,
-            showEffect: true,
-            enemyLives: newEnemyLives,
-            message: `太棒了! 對怪物造成 ${damage} 點傷害!`,
-            isBossShaking: true,
-            correctAnswers: state.correctAnswers + 1,
-        };
-    case 'HANDLE_PUZZLE_CORRECT':
-        const newCollectedTools = [...state.collectedTools, action.payload.word];
-        return {
-            ...state,
-            score: state.score + POINTS_PER_PUZZLE,
-            combo: state.combo + 1,
-            showEffect: true,
-            collectedTools: newCollectedTools,
-            message: `獲得了 ${action.payload.word}!`,
-            correctAnswers: state.correctAnswers + 1,
-        };
-    case 'HANDLE_INCORRECT_ANSWER':
-        return { ...state, message: '再試一次!', combo: 0 };
-    case 'NEXT_LEVEL':
-        const nextLevelIndex = state.currentLevel + 1;
-        if (nextLevelIndex >= state.levels.length) {
-            return { ...state, gameState: 'victory' };
-        }
-        const message = action.payload?.from === 'puzzle'
-            ? '謎題解開! 進入下一關!'
-            : '關卡完成! 進入下一關!';
-        return {
-            ...state,
-            currentLevel: nextLevelIndex,
-            enemyLives: state.levels[nextLevelIndex]?.enemyLives || 5,
-            collectedTools: [], // Reset for new puzzle level
-            message: message,
-        };
-    case 'SET_USER_INPUT':
-        return { ...state, userInput: action.payload };
-    case 'SET_MESSAGE':
-        return { ...state, message: action.payload };
-    case 'TOGGLE_PRACTICE_MODE':
-      return { ...state, practiceMode: state.practiceMode === 'voice' ? 'spelling' : 'voice' };
-    case 'SET_PRACTICE_MODE':
-      return { ...state, practiceMode: action.payload };
-    case 'SET_SHOW_HINT':
-        return { ...state, showHint: action.payload };
-    case 'SET_RECOGNITION_LANG':
-        return { ...state, recognitionLang: action.payload };
-    case 'SKIP_WORD':
-        return { ...state, combo: 0 };
-    case 'SET_COMBO':
-      return { ...state, combo: action.payload };
-    case 'RESET_EFFECTS':
-        return { ...state, showEffect: false, isBossShaking: false };
-    default:
-      return state;
-  }
-}
-
-
 interface AppProps {
     initialVocab?: VocabItem[];
     initialLevels?: Level[];
 }
 
 const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels = defaultLevels }) => {
-  const [state, dispatch] = useReducer(appReducer, {
-    ...initialState,
+  const [state, dispatch] = useReducer(gameReducer, createInitialState({
     levels: initialLevels,
-  });
+    recognitionLang: loadLangFromStorage(),
+  }));
   const {
     vocab,
     levels,
@@ -257,11 +105,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     }
 
     const level = levels[currentLevel];
-    let availableWords = enabledVocab;
-    
-    if (level.type === 'puzzle' && level.tools) {
-      availableWords = enabledVocab.filter((w: VocabItem) => level.tools?.includes(w.word) && !collectedTools.includes(w.word));
-    } 
+    const availableWords = getAvailableWords(vocab, level, collectedTools);
     
     if (availableWords.length > 0) {
       const randomWord = availableWords[Math.floor(Math.random() * availableWords.length)];
@@ -296,12 +140,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     const effectTimer = setTimeout(() => dispatch({ type: 'RESET_EFFECTS' }), 500);
 
     const level = levels[currentLevel];
-    let levelComplete = false;
-    if (level.type === 'boss' && enemyLives <= 0) {
-        levelComplete = true;
-    } else if (level.type === 'puzzle' && collectedTools.length >= (level.tools?.length || 0)) {
-        levelComplete = true;
-    }
+    const levelComplete = isLevelComplete(level, { enemyLives, collectedTools });
 
     // After a longer delay, advance the game
     const gameFlowTimer = setTimeout(() => {
@@ -345,14 +184,13 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   const handleSubmit = (submittedText: string) => {
     if (!currentWord) return;
     
-    const isCorrect = submittedText.toLowerCase().trim().replace(/[^a-z]/g, '') === currentWord.word;
+    const isCorrect = isAnswerCorrect(submittedText, currentWord);
     
     if (isCorrect) {
       const level = levels[currentLevel];
       
       if (level.type === 'boss') {
-        const damage = currentWord.difficulty;
-        const points = currentWord.difficulty * BASE_POINTS_PER_WORD * (combo + 1);
+        const { damage, points } = calculateBossReward(currentWord, combo);
         dispatch({ type: 'HANDLE_CORRECT_ANSWER', payload: { points, damage, word: currentWord.word } });
       } else if (level.type === 'puzzle') {
         dispatch({ type: 'HANDLE_PUZZLE_CORRECT', payload: { word: currentWord.word } });

--- a/web/src/components/VocabManager.test.tsx
+++ b/web/src/components/VocabManager.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { VocabManager, VocabItem, fileNameToWord, parseDifficultyFromPath } from './VocabManager';
+import { VocabManager, fileNameToWord, parseDifficultyFromPath } from './VocabManager';
+import type { VocabItem } from '../types/vocab';
 
 // Mock data for testing the component
 const mockVocab: VocabItem[] = [

--- a/web/src/components/VocabManager.tsx
+++ b/web/src/components/VocabManager.tsx
@@ -1,18 +1,7 @@
 import React, { useRef, useEffect } from 'react';
+import type { VocabItem } from '../types/vocab';
 
-// Type definitions moved to a central place, e.g., src/types.ts
-// For now, we redefine them here.
-export interface VocabItem {
-  id: string;
-  word: string;
-  imageDataUrl?: string;
-  imageName: string;
-  size: number;
-  type: string;
-  difficulty: number;
-  enabled: boolean;
-  pathHint?: string;
-}
+export type { VocabItem } from '../types/vocab';
 
 const MAX_IMAGE_BYTES = 1024 * 1024; // 1MB
 

--- a/web/src/data/vocab.ts
+++ b/web/src/data/vocab.ts
@@ -1,4 +1,4 @@
-import { VocabItem } from '../components/VocabManager';
+import type { VocabItem } from '../types/vocab';
 
 export const initialVocab: VocabItem[] = [
     // Difficulty 1

--- a/web/src/game/architecture.test.ts
+++ b/web/src/game/architecture.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+const gameSourceFiles = ['gameLogic.ts', 'gameReducer.ts'];
+
+describe('game architecture boundaries', () => {
+  it('keeps game modules independent from UI components', () => {
+    for (const fileName of gameSourceFiles) {
+      const source = fs.readFileSync(path.join(__dirname, fileName), 'utf8');
+
+      expect(source).not.toMatch(/from ['"]\.\.\/components\//);
+    }
+  });
+});

--- a/web/src/game/gameLogic.test.ts
+++ b/web/src/game/gameLogic.test.ts
@@ -1,0 +1,118 @@
+import type { Level } from '../data/levels';
+import type { VocabItem } from '../types/vocab';
+import {
+  calculateBossReward,
+  getAvailableWords,
+  isAnswerCorrect,
+  isLevelComplete,
+} from './gameLogic';
+
+const vocab = (word: string, overrides: Partial<VocabItem> = {}): VocabItem => ({
+  id: word,
+  word,
+  difficulty: 1,
+  enabled: true,
+  imageName: word,
+  size: 0,
+  type: '',
+  ...overrides,
+});
+
+describe('gameLogic', () => {
+  describe('isAnswerCorrect', () => {
+    it('accepts case, spacing, and punctuation differences around the target word', () => {
+      expect(isAnswerCorrect('  HAM-mer! ', vocab('hammer'))).toBe(true);
+    });
+
+    it('rejects answers that normalize to a different word', () => {
+      expect(isAnswerCorrect('ham', vocab('hammer'))).toBe(false);
+    });
+  });
+
+  describe('calculateBossReward', () => {
+    it('uses difficulty for damage and combo-scaled score', () => {
+      expect(calculateBossReward(vocab('shield', { difficulty: 3 }), 2)).toEqual({
+        damage: 3,
+        points: 90,
+      });
+    });
+  });
+
+  describe('getAvailableWords', () => {
+    const bossLevel: Level = {
+      id: 1,
+      name: 'Boss',
+      type: 'boss',
+      description: '',
+      imageEmoji: '',
+      requiredWords: 2,
+      enemyLives: 3,
+    };
+
+    const puzzleLevel: Level = {
+      id: 2,
+      name: 'Puzzle',
+      type: 'puzzle',
+      description: '',
+      imageEmoji: '',
+      requiredWords: 2,
+      tools: ['key', 'hammer'],
+    };
+
+    it('returns enabled words for boss levels', () => {
+      const words = [
+        vocab('apple'),
+        vocab('disabled', { enabled: false }),
+        vocab('shield'),
+      ];
+
+      expect(getAvailableWords(words, bossLevel, [])).toEqual([
+        vocab('apple'),
+        vocab('shield'),
+      ]);
+    });
+
+    it('returns uncollected puzzle tool words only', () => {
+      const words = [
+        vocab('key'),
+        vocab('hammer'),
+        vocab('apple'),
+        vocab('disabled', { enabled: false }),
+      ];
+
+      expect(getAvailableWords(words, puzzleLevel, ['key'])).toEqual([
+        vocab('hammer'),
+      ]);
+    });
+  });
+
+  describe('isLevelComplete', () => {
+    it('completes a boss level when enemy lives reach zero', () => {
+      const bossLevel: Level = {
+        id: 1,
+        name: 'Boss',
+        type: 'boss',
+        description: '',
+        imageEmoji: '',
+        requiredWords: 1,
+        enemyLives: 1,
+      };
+
+      expect(isLevelComplete(bossLevel, { enemyLives: 0, collectedTools: [] })).toBe(true);
+    });
+
+    it('completes a puzzle level when all tools are collected', () => {
+      const puzzleLevel: Level = {
+        id: 2,
+        name: 'Puzzle',
+        type: 'puzzle',
+        description: '',
+        imageEmoji: '',
+        requiredWords: 2,
+        tools: ['key', 'hammer'],
+      };
+
+      expect(isLevelComplete(puzzleLevel, { enemyLives: 3, collectedTools: ['key', 'hammer'] })).toBe(true);
+    });
+  });
+});

--- a/web/src/game/gameLogic.ts
+++ b/web/src/game/gameLogic.ts
@@ -1,0 +1,44 @@
+import type { VocabItem } from '../types/vocab';
+import type { Level } from '../data/levels';
+
+const BASE_POINTS_PER_WORD = 10;
+
+export function normalizeAnswer(answer: string): string {
+  return answer.toLowerCase().trim().replace(/[^a-z]/g, '');
+}
+
+export function isAnswerCorrect(answer: string, currentWord: VocabItem): boolean {
+  return normalizeAnswer(answer) === currentWord.word;
+}
+
+export function calculateBossReward(currentWord: VocabItem, combo: number) {
+  return {
+    damage: currentWord.difficulty,
+    points: currentWord.difficulty * BASE_POINTS_PER_WORD * (combo + 1),
+  };
+}
+
+export function getAvailableWords(
+  vocab: VocabItem[],
+  level: Level,
+  collectedTools: string[],
+): VocabItem[] {
+  const enabledVocab = vocab.filter((word) => word.enabled);
+
+  if (level.type === 'puzzle' && level.tools) {
+    return enabledVocab.filter((word) => level.tools?.includes(word.word) && !collectedTools.includes(word.word));
+  }
+
+  return enabledVocab;
+}
+
+export function isLevelComplete(
+  level: Level,
+  progress: { enemyLives: number; collectedTools: string[] },
+): boolean {
+  if (level.type === 'boss') {
+    return progress.enemyLives <= 0;
+  }
+
+  return progress.collectedTools.length >= (level.tools?.length || 0);
+}

--- a/web/src/game/gameReducer.test.ts
+++ b/web/src/game/gameReducer.test.ts
@@ -1,0 +1,94 @@
+import { Level } from '../data/levels';
+import { createInitialState, gameReducer } from './gameReducer';
+
+const levels: Level[] = [
+  {
+    id: 1,
+    name: 'First',
+    type: 'boss',
+    description: '',
+    imageEmoji: '',
+    requiredWords: 1,
+    enemyLives: 4,
+  },
+  {
+    id: 2,
+    name: 'Second',
+    type: 'puzzle',
+    description: '',
+    imageEmoji: '',
+    requiredWords: 2,
+    tools: ['key', 'hammer'],
+  },
+];
+
+describe('gameReducer', () => {
+  it('creates a menu state with provided levels and recognition language', () => {
+    const state = createInitialState({ levels, recognitionLang: 'en-GB' });
+
+    expect(state.gameState).toBe('menu');
+    expect(state.levels).toBe(levels);
+    expect(state.recognitionLang).toBe('en-GB');
+  });
+
+  it('starts a new game from the first level and resets run progress', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      currentLevel: 1,
+      score: 120,
+      enemyLives: 1,
+      collectedTools: ['key'],
+      correctAnswers: 5,
+      combo: 3,
+      message: 'old message',
+    };
+
+    expect(gameReducer(state, { type: 'START_GAME' })).toMatchObject({
+      gameState: 'playing',
+      currentLevel: 0,
+      score: 0,
+      enemyLives: 4,
+      collectedTools: [],
+      correctAnswers: 0,
+      combo: 0,
+      message: '',
+    });
+  });
+
+  it('applies boss answer rewards to score, combo, lives, and feedback state', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      gameState: 'playing' as const,
+      enemyLives: 4,
+      score: 10,
+      combo: 1,
+      correctAnswers: 2,
+    };
+
+    expect(
+      gameReducer(state, {
+        type: 'HANDLE_CORRECT_ANSWER',
+        payload: { points: 40, damage: 2, word: 'shield' },
+      }),
+    ).toMatchObject({
+      score: 50,
+      combo: 2,
+      enemyLives: 2,
+      showEffect: true,
+      isBossShaking: true,
+      correctAnswers: 3,
+      message: '太棒了! 對怪物造成 2 點傷害!',
+    });
+  });
+
+  it('moves to victory when advancing beyond the final level', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      currentLevel: 1,
+    };
+
+    expect(gameReducer(state, { type: 'NEXT_LEVEL' })).toMatchObject({
+      gameState: 'victory',
+    });
+  });
+});

--- a/web/src/game/gameReducer.ts
+++ b/web/src/game/gameReducer.ts
@@ -1,0 +1,174 @@
+import type { VocabItem } from '../types/vocab';
+import { defaultLevels, type Level } from '../data/levels';
+
+export type GameState = 'menu' | 'playing' | 'victory' | 'vocab_management';
+
+export interface AppState {
+  vocab: VocabItem[];
+  levels: Level[];
+  currentLevel: number;
+  currentWord: VocabItem | null;
+  userInput: string;
+  score: number;
+  enemyLives: number;
+  collectedTools: string[];
+  message: string;
+  practiceMode: 'voice' | 'spelling';
+  gameState: GameState;
+  correctAnswers: number;
+  showEffect: boolean;
+  combo: number;
+  showHint: boolean;
+  isBossShaking: boolean;
+  recognitionLang: string;
+}
+
+export type AppAction =
+  | { type: 'SET_VOCAB'; payload: VocabItem[] }
+  | { type: 'SET_LEVELS'; payload: Level[] }
+  | { type: 'START_GAME' }
+  | { type: 'SET_GAME_STATE'; payload: GameState }
+  | { type: 'SELECT_NEW_WORD'; payload: VocabItem | null }
+  | { type: 'HANDLE_CORRECT_ANSWER'; payload: { points: number; damage: number; word: string } }
+  | { type: 'HANDLE_PUZZLE_CORRECT'; payload: { word: string } }
+  | { type: 'HANDLE_INCORRECT_ANSWER' }
+  | { type: 'NEXT_LEVEL'; payload?: { from: 'puzzle' | 'boss' } }
+  | { type: 'SET_USER_INPUT'; payload: string }
+  | { type: 'SET_MESSAGE'; payload: string }
+  | { type: 'TOGGLE_PRACTICE_MODE' }
+  | { type: 'SET_PRACTICE_MODE'; payload: AppState['practiceMode'] }
+  | { type: 'SET_SHOW_HINT'; payload: boolean }
+  | { type: 'SET_RECOGNITION_LANG'; payload: string }
+  | { type: 'SKIP_WORD' }
+  | { type: 'SET_COMBO'; payload: number }
+  | { type: 'RESET_EFFECTS' };
+
+export const POINTS_PER_PUZZLE = 10;
+
+interface InitialStateOptions {
+  levels?: Level[];
+  recognitionLang?: string;
+}
+
+export function createInitialState({
+  levels = defaultLevels,
+  recognitionLang = 'en-US',
+}: InitialStateOptions = {}): AppState {
+  return {
+    vocab: [],
+    levels,
+    currentLevel: 0,
+    currentWord: null,
+    userInput: '',
+    score: 0,
+    enemyLives: 5,
+    collectedTools: [],
+    message: '',
+    practiceMode: 'voice',
+    gameState: 'menu',
+    correctAnswers: 0,
+    showEffect: false,
+    combo: 0,
+    showHint: false,
+    isBossShaking: false,
+    recognitionLang,
+  };
+}
+
+export function gameReducer(state: AppState, action: AppAction): AppState {
+  switch (action.type) {
+    case 'SET_VOCAB':
+      return { ...state, vocab: action.payload };
+    case 'SET_LEVELS':
+      return { ...state, levels: action.payload };
+    case 'START_GAME':
+      return {
+        ...state,
+        gameState: 'playing',
+        currentLevel: 0,
+        score: 0,
+        enemyLives: state.levels[0]?.enemyLives || 5,
+        collectedTools: [],
+        correctAnswers: 0,
+        combo: 0,
+        message: '',
+      };
+    case 'SET_GAME_STATE':
+      return {
+        ...state,
+        gameState: action.payload,
+        message: action.payload === 'menu' ? '請先到字彙管理新增單字!' : '',
+      };
+    case 'SELECT_NEW_WORD':
+      return { ...state, currentWord: action.payload, userInput: '' };
+    case 'HANDLE_CORRECT_ANSWER': {
+      const { points, damage } = action.payload;
+      const newEnemyLives = state.enemyLives - damage;
+
+      return {
+        ...state,
+        score: state.score + points,
+        combo: state.combo + 1,
+        showEffect: true,
+        enemyLives: newEnemyLives,
+        message: `太棒了! 對怪物造成 ${damage} 點傷害!`,
+        isBossShaking: true,
+        correctAnswers: state.correctAnswers + 1,
+      };
+    }
+    case 'HANDLE_PUZZLE_CORRECT': {
+      const newCollectedTools = [...state.collectedTools, action.payload.word];
+
+      return {
+        ...state,
+        score: state.score + POINTS_PER_PUZZLE,
+        combo: state.combo + 1,
+        showEffect: true,
+        collectedTools: newCollectedTools,
+        message: `獲得了 ${action.payload.word}!`,
+        correctAnswers: state.correctAnswers + 1,
+      };
+    }
+    case 'HANDLE_INCORRECT_ANSWER':
+      return { ...state, message: '再試一次!', combo: 0 };
+    case 'NEXT_LEVEL': {
+      const nextLevelIndex = state.currentLevel + 1;
+
+      if (nextLevelIndex >= state.levels.length) {
+        return { ...state, gameState: 'victory' };
+      }
+
+      const message = action.payload?.from === 'puzzle'
+        ? '謎題解開! 進入下一關!'
+        : '關卡完成! 進入下一關!';
+
+      return {
+        ...state,
+        currentLevel: nextLevelIndex,
+        enemyLives: state.levels[nextLevelIndex]?.enemyLives || 5,
+        collectedTools: [],
+        message,
+      };
+    }
+    case 'SET_USER_INPUT':
+      return { ...state, userInput: action.payload };
+    case 'SET_MESSAGE':
+      return { ...state, message: action.payload };
+    case 'TOGGLE_PRACTICE_MODE':
+      return { ...state, practiceMode: state.practiceMode === 'voice' ? 'spelling' : 'voice' };
+    case 'SET_PRACTICE_MODE':
+      return { ...state, practiceMode: action.payload };
+    case 'SET_SHOW_HINT':
+      return { ...state, showHint: action.payload };
+    case 'SET_RECOGNITION_LANG':
+      return { ...state, recognitionLang: action.payload };
+    case 'SKIP_WORD':
+      return { ...state, combo: 0 };
+    case 'SET_COMBO':
+      return { ...state, combo: action.payload };
+    case 'RESET_EFFECTS':
+      return { ...state, showEffect: false, isBossShaking: false };
+    default:
+      return state;
+  }
+}

--- a/web/src/types/vocab.ts
+++ b/web/src/types/vocab.ts
@@ -1,0 +1,11 @@
+export interface VocabItem {
+  id: string;
+  word: string;
+  imageDataUrl?: string;
+  imageName: string;
+  size: number;
+  type: string;
+  difficulty: number;
+  enabled: boolean;
+  pathHint?: string;
+}


### PR DESCRIPTION
## Summary
- Extract pure game logic helpers for answer normalization, word availability, boss rewards, and level completion
- Move app state, actions, initial state, and reducer into a focused game reducer module
- Move `VocabItem` into a shared non-UI type module so game logic no longer depends on UI components
- Add unit tests for game logic, reducer behavior, and the game-layer architecture boundary

## Verification
- `npm test -- --runInBand` (47 passed)
- `npm run build`
- GitHub Actions `validate` (success)

Refs #55