### PR TITLE
Improve gameplay loop goals and choices

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -118,8 +118,52 @@ describe('<App />', () => {
     await waitFor(() => {
         expect(screen.getByText('關卡 1')).toBeInTheDocument();
     });
-    expect(screen.getByText('⚔️')).toBeInTheDocument();
+    expect(screen.getByText('🍎')).toBeInTheDocument();
     expect(screen.getByText('分數: 0')).toBeInTheDocument();
+  });
+
+  it('shows a visible boss objective based on required words', async () => {
+    const objectiveLevels: Level[] = [
+      { id: 1, name: 'Goal Boss', type: 'boss', enemyLives: 10, description: '', imageEmoji: 'G', requiredWords: 2 },
+    ];
+
+    render(<App initialLevels={objectiveLevels} initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('目標: 答對 0/2 個單字')).toBeInTheDocument();
+    });
+  });
+
+  it('advances a boss level after meeting requiredWords even when enemy lives remain', async () => {
+    jest.useFakeTimers();
+    const goalLevels: Level[] = [
+      { id: 1, name: 'Word Goal', type: 'boss', enemyLives: 10, description: '', imageEmoji: 'W', requiredWords: 1 },
+      { id: 2, name: 'Next Goal', type: 'boss', enemyLives: 1, description: '', imageEmoji: 'N', requiredWords: 1 },
+    ];
+    const goalVocab: VocabItem[] = [
+      { id: '1', word: 'apple', difficulty: 1, enabled: true, imageName: '🍎', size: 1, type: 'image/png' },
+    ];
+
+    render(<App initialLevels={goalLevels} initialVocab={goalVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Word Goal')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到拼字模式/i }));
+    fireEvent.change(screen.getByPlaceholderText('輸入英文單字'), { target: { value: 'apple' } });
+    fireEvent.click(screen.getByText('攻擊!'));
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Next Goal')).toBeInTheDocument();
+    });
+    jest.useRealTimers();
   });
 
   it('should handle a correct text input answer', async () => {
@@ -135,14 +179,15 @@ describe('<App />', () => {
     const input = screen.getByPlaceholderText('輸入英文單字');
     const attackButton = screen.getByText('攻擊!');
 
-    fireEvent.change(input, { target: { value: 'sword' } });
+    fireEvent.change(input, { target: { value: 'apple' } });
     fireEvent.click(attackButton);
 
     await waitFor(() => {
       expect(screen.getByText(/太棒了!/)).toBeInTheDocument();
     });
-    expect(screen.getByText('分數: 20')).toBeInTheDocument();
-    expect(screen.getByText(/對怪物造成 2 點傷害!/)).toBeInTheDocument();
+    expect(screen.getByText('分數: 10')).toBeInTheDocument();
+    expect(screen.getByText(/對怪物造成 1 點傷害!/)).toBeInTheDocument();
+    expect(screen.getByText('目標: 答對 1/5 個單字')).toBeInTheDocument();
   });
 
   it('should handle an incorrect text input answer', async () => {
@@ -162,7 +207,7 @@ describe('<App />', () => {
     fireEvent.click(attackButton);
 
     await waitFor(() => {
-      expect(screen.getByText('再試一次!')).toBeInTheDocument();
+      expect(screen.getByText('再試一次! 連擊歸零，但不扣分。')).toBeInTheDocument();
     });
     expect(screen.getByText('分數: 0')).toBeInTheDocument();
   });
@@ -171,35 +216,37 @@ describe('<App />', () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));
     await waitFor(() => {
-      expect(screen.getByText('⚔️')).toBeInTheDocument();
+      expect(screen.getByText('🍎')).toBeInTheDocument();
     });
 
     const skipButton = screen.getByRole('button', { name: /skip word/i });
     fireEvent.click(skipButton);
 
     await waitFor(() => {
-      expect(screen.getByText('🛡️')).toBeInTheDocument();
+      expect(screen.getByText('⚔️')).toBeInTheDocument();
     });
+    expect(screen.getByText('已跳過這題：扣 5 分並失去連擊。')).toBeInTheDocument();
+    expect(screen.getByText('跳過 1 次')).toBeInTheDocument();
   });
 
   it('should show a hint when the hint button is held down', async () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));
     await waitFor(() => {
-      expect(screen.getByText('⚔️')).toBeInTheDocument();
+      expect(screen.getByText('🍎')).toBeInTheDocument();
     });
 
     const hintButton = screen.getByRole('button', { name: /show hint/i });
     fireEvent.mouseDown(hintButton);
 
     await waitFor(() => {
-        expect(screen.getByText('sword')).toBeInTheDocument();
+        expect(screen.getByText('apple')).toBeInTheDocument();
     });
 
     fireEvent.mouseUp(hintButton);
 
     await waitFor(() => {
-        expect(screen.queryByText('sword')).not.toBeInTheDocument();
+        expect(screen.queryByText('apple')).not.toBeInTheDocument();
     });
   });
 
@@ -391,12 +438,12 @@ describe('<App />', () => {
       recognition.onstart?.();
       recognition.onresult?.({
         resultIndex: 0,
-        results: [{ isFinal: true, 0: { transcript: 'sword' } }],
+        results: [{ isFinal: true, 0: { transcript: 'apple' } }],
       });
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/太棒了! 對怪物造成 2 點傷害!/)).toBeInTheDocument();
+      expect(screen.getByText(/太棒了! \+10 分，對怪物造成 1 點傷害!/)).toBeInTheDocument();
     });
     expect(screen.getByText('聆聽中...')).toBeInTheDocument();
   });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -131,8 +131,37 @@ describe('<App />', () => {
     fireEvent.click(screen.getByText('開始遊戲'));
 
     await waitFor(() => {
-      expect(screen.getByText('目標: 答對 0/2 個單字')).toBeInTheDocument();
+      expect(screen.getByText('目標: 答對 0/2 個單字，或清空生命值 10/10')).toBeInTheDocument();
     });
+  });
+
+  it('keeps a constrained boss level playable when imported words are below the difficulty range', async () => {
+    const constrainedLevels: Level[] = [
+      {
+        id: 1,
+        name: 'Hard Gate',
+        type: 'boss',
+        enemyLives: 3,
+        description: '',
+        imageEmoji: 'H',
+        requiredWords: 2,
+        minDifficulty: 3,
+        maxDifficulty: 5,
+      },
+      { id: 2, name: 'Skipped Gate', type: 'boss', enemyLives: 1, description: '', imageEmoji: 'S', requiredWords: 1 },
+    ];
+    const importedVocab: VocabItem[] = [
+      { id: 'apple', word: 'apple', difficulty: 1, enabled: true, imageName: '🍎', size: 1, type: 'image/png' },
+    ];
+
+    render(<App initialLevels={constrainedLevels} initialVocab={importedVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('🍎')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Hard Gate')).toBeInTheDocument();
+    expect(screen.queryByText('Skipped Gate')).not.toBeInTheDocument();
   });
 
   it('advances a boss level after meeting requiredWords even when enemy lives remain', async () => {
@@ -187,7 +216,7 @@ describe('<App />', () => {
     });
     expect(screen.getByText('分數: 10')).toBeInTheDocument();
     expect(screen.getByText(/對怪物造成 1 點傷害!/)).toBeInTheDocument();
-    expect(screen.getByText('目標: 答對 1/5 個單字')).toBeInTheDocument();
+    expect(screen.getByText('目標: 答對 1/5 個單字，或清空生命值 4/5')).toBeInTheDocument();
   });
 
   it('should handle an incorrect text input answer', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@ import type { VocabItem } from './types/vocab';
 import { initialVocab as defaultInitialVocab } from './data/vocab';
 import { useSpeechRecognition } from './hooks/useSpeechRecognition';
 import { defaultLevels, type Level } from './data/levels';
-import { calculateBossReward, getAvailableWords, isAnswerCorrect, isLevelComplete } from './game/gameLogic';
+import { calculateBossReward, getAvailableWords, isAnswerCorrect, isLevelComplete, selectWord } from './game/gameLogic';
 import { createInitialState, gameReducer } from './game/gameReducer';
 
 
@@ -58,6 +58,8 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     practiceMode,
     gameState,
     correctAnswers,
+    levelCorrectAnswers,
+    skippedWords,
     showEffect,
     combo,
     showHint,
@@ -108,7 +110,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     const availableWords = getAvailableWords(vocab, level, collectedTools);
     
     if (availableWords.length > 0) {
-      const randomWord = availableWords[Math.floor(Math.random() * availableWords.length)];
+      const randomWord = selectWord(availableWords, Math.random, currentWord?.id);
       dispatch({ type: 'SELECT_NEW_WORD', payload: randomWord });
     } else {
         // No more words for this level
@@ -140,7 +142,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     const effectTimer = setTimeout(() => dispatch({ type: 'RESET_EFFECTS' }), 500);
 
     const level = levels[currentLevel];
-    const levelComplete = isLevelComplete(level, { enemyLives, collectedTools });
+    const levelComplete = isLevelComplete(level, { enemyLives, collectedTools, levelCorrectAnswers });
 
     // After a longer delay, advance the game
     const gameFlowTimer = setTimeout(() => {
@@ -159,7 +161,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
         clearTimeout(effectTimer);
         clearTimeout(gameFlowTimer);
     };
-  }, [correctAnswers, gameState, enemyLives, collectedTools, currentLevel, levels]);
+  }, [correctAnswers, gameState, enemyLives, collectedTools, levelCorrectAnswers, currentLevel, levels]);
 
   // Persist language selection
   useEffect(() => {
@@ -256,6 +258,9 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   const renderGame = () => {
     const level = levels[currentLevel];
     const speechUnavailable = !speech.isSupported;
+    const objectiveText = level.type === 'puzzle'
+      ? `目標: 收集 ${collectedTools.length}/${level.tools?.length || level.requiredWords} 個工具`
+      : `目標: 答對 ${levelCorrectAnswers}/${level.requiredWords} 個單字`;
     
     return (
       <div className="min-h-screen bg-gradient-to-b from-purple-400 to-pink-300 p-8">
@@ -270,6 +275,9 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
                 <Zap className="w-6 h-6 text-yellow-500" />
                 <span className="text-lg font-semibold text-gray-700">連擊 x{combo}</span>
               </div>
+              <div className="text-sm font-semibold text-gray-600">
+                跳過 {skippedWords} 次
+              </div>
               <div className="flex items-center gap-4">
                 <Star className="w-8 h-8 text-yellow-500" />
                 <span className="text-xl font-bold text-gray-800">關卡 {currentLevel + 1}</span>
@@ -281,6 +289,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
             <div className="bg-white rounded-2xl shadow-xl p-6 md:w-1/2">
               <h2 className="text-3xl font-bold text-center mb-2 text-purple-600">{level.name}</h2>
               <p className="text-center text-gray-600 mb-4">{level.description}</p>
+              <p className="text-center text-indigo-700 font-semibold mb-4">{objectiveText}</p>
 
               <div className={`my-4 text-center text-9xl ${isBossShaking ? 'shake' : ''}`}>
                 {level.imageEmoji}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -258,9 +258,10 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   const renderGame = () => {
     const level = levels[currentLevel];
     const speechUnavailable = !speech.isSupported;
+    const totalEnemyLives = level.enemyLives ?? enemyLives;
     const objectiveText = level.type === 'puzzle'
       ? `目標: 收集 ${collectedTools.length}/${level.tools?.length || level.requiredWords} 個工具`
-      : `目標: 答對 ${levelCorrectAnswers}/${level.requiredWords} 個單字`;
+      : `目標: 答對 ${levelCorrectAnswers}/${level.requiredWords} 個單字，或清空生命值 ${enemyLives}/${totalEnemyLives}`;
     
     return (
       <div className="min-h-screen bg-gradient-to-b from-purple-400 to-pink-300 p-8">

--- a/web/src/data/levels.ts
+++ b/web/src/data/levels.ts
@@ -7,6 +7,8 @@ export interface Level {
   requiredWords: number;
   enemyLives?: number;
   tools?: string[];
+  minDifficulty?: number;
+  maxDifficulty?: number;
 }
 
 // Define default levels so they can be exported or used as a default prop
@@ -18,7 +20,9 @@ export const defaultLevels: Level[] = [
       description: '打敗守護寶藏的巨龍！',
       imageEmoji: '🐉',
       requiredWords: 5,
-      enemyLives: 5
+      enemyLives: 5,
+      minDifficulty: 1,
+      maxDifficulty: 2
     },
     {
       id: 2,
@@ -27,7 +31,9 @@ export const defaultLevels: Level[] = [
       description: '一隻討厭的哥布林擋住了去路！',
       imageEmoji: '👺',
       requiredWords: 5,
-      enemyLives: 3
+      enemyLives: 3,
+      minDifficulty: 2,
+      maxDifficulty: 3
     },
     {
       id: 3,
@@ -36,7 +42,9 @@ export const defaultLevels: Level[] = [
       description: '巨大的石像巨人覺醒了！',
       imageEmoji: '🗿',
       requiredWords: 5,
-      enemyLives: 8
+      enemyLives: 8,
+      minDifficulty: 2,
+      maxDifficulty: 4
     },
     {
       id: 4,
@@ -45,7 +53,9 @@ export const defaultLevels: Level[] = [
       description: '最終挑戰：擊敗魔王！',
       imageEmoji: '👿',
       requiredWords: 5,
-      enemyLives: 12
+      enemyLives: 12,
+      minDifficulty: 3,
+      maxDifficulty: 5
     },
     {
       id: 5,

--- a/web/src/game/gameLogic.test.ts
+++ b/web/src/game/gameLogic.test.ts
@@ -97,6 +97,17 @@ describe('gameLogic', () => {
         vocab('shield', { difficulty: 3 }),
       ]);
     });
+
+    it('falls back to enabled boss words when difficulty constraints would empty the pool', () => {
+      const words = [
+        vocab('apple', { difficulty: 1 }),
+        vocab('disabled', { difficulty: 1, enabled: false }),
+      ];
+
+      expect(getAvailableWords(words, { ...bossLevel, minDifficulty: 3, maxDifficulty: 5 }, [])).toEqual([
+        vocab('apple', { difficulty: 1 }),
+      ]);
+    });
   });
 
   describe('selectWord', () => {

--- a/web/src/game/gameLogic.test.ts
+++ b/web/src/game/gameLogic.test.ts
@@ -5,6 +5,7 @@ import {
   getAvailableWords,
   isAnswerCorrect,
   isLevelComplete,
+  selectWord,
 } from './gameLogic';
 
 const vocab = (word: string, overrides: Partial<VocabItem> = {}): VocabItem => ({
@@ -84,10 +85,36 @@ describe('gameLogic', () => {
         vocab('hammer'),
       ]);
     });
+
+    it('applies level difficulty constraints to boss word pools', () => {
+      const words = [
+        vocab('apple', { difficulty: 1 }),
+        vocab('shield', { difficulty: 3 }),
+        vocab('castle', { difficulty: 4 }),
+      ];
+
+      expect(getAvailableWords(words, { ...bossLevel, minDifficulty: 2, maxDifficulty: 3 }, [])).toEqual([
+        vocab('shield', { difficulty: 3 }),
+      ]);
+    });
+  });
+
+  describe('selectWord', () => {
+    it('avoids selecting the previous word when another option is available', () => {
+      const words = [vocab('apple'), vocab('shield'), vocab('castle')];
+
+      expect(selectWord(words, () => 0, 'apple')?.word).toBe('shield');
+    });
+
+    it('allows selecting the previous word when it is the only available option', () => {
+      const words = [vocab('apple')];
+
+      expect(selectWord(words, () => 0.75, 'apple')?.word).toBe('apple');
+    });
   });
 
   describe('isLevelComplete', () => {
-    it('completes a boss level when enemy lives reach zero', () => {
+    it('completes a boss level when the required word goal is reached', () => {
       const bossLevel: Level = {
         id: 1,
         name: 'Boss',
@@ -95,10 +122,24 @@ describe('gameLogic', () => {
         description: '',
         imageEmoji: '',
         requiredWords: 1,
-        enemyLives: 1,
+        enemyLives: 5,
       };
 
-      expect(isLevelComplete(bossLevel, { enemyLives: 0, collectedTools: [] })).toBe(true);
+      expect(isLevelComplete(bossLevel, { enemyLives: 5, collectedTools: [], levelCorrectAnswers: 1 })).toBe(true);
+    });
+
+    it('keeps a boss level active until either word goal or lives are cleared', () => {
+      const bossLevel: Level = {
+        id: 1,
+        name: 'Boss',
+        type: 'boss',
+        description: '',
+        imageEmoji: '',
+        requiredWords: 2,
+        enemyLives: 5,
+      };
+
+      expect(isLevelComplete(bossLevel, { enemyLives: 4, collectedTools: [], levelCorrectAnswers: 1 })).toBe(false);
     });
 
     it('completes a puzzle level when all tools are collected', () => {
@@ -112,7 +153,7 @@ describe('gameLogic', () => {
         tools: ['key', 'hammer'],
       };
 
-      expect(isLevelComplete(puzzleLevel, { enemyLives: 3, collectedTools: ['key', 'hammer'] })).toBe(true);
+      expect(isLevelComplete(puzzleLevel, { enemyLives: 3, collectedTools: ['key', 'hammer'], levelCorrectAnswers: 2 })).toBe(true);
     });
   });
 });

--- a/web/src/game/gameLogic.ts
+++ b/web/src/game/gameLogic.ts
@@ -30,16 +30,23 @@ export function getAvailableWords(
   }
 
   const { minDifficulty, maxDifficulty } = level;
+  const hasDifficultyConstraint = minDifficulty !== undefined || maxDifficulty !== undefined;
+
+  if (!hasDifficultyConstraint) {
+    return availableVocab;
+  }
+
+  let difficultyMatchedVocab = availableVocab;
 
   if (minDifficulty !== undefined) {
-    availableVocab = availableVocab.filter((word) => word.difficulty >= minDifficulty);
+    difficultyMatchedVocab = difficultyMatchedVocab.filter((word) => word.difficulty >= minDifficulty);
   }
 
   if (maxDifficulty !== undefined) {
-    availableVocab = availableVocab.filter((word) => word.difficulty <= maxDifficulty);
+    difficultyMatchedVocab = difficultyMatchedVocab.filter((word) => word.difficulty <= maxDifficulty);
   }
 
-  return availableVocab;
+  return difficultyMatchedVocab.length > 0 ? difficultyMatchedVocab : availableVocab;
 }
 
 export function selectWord(

--- a/web/src/game/gameLogic.ts
+++ b/web/src/game/gameLogic.ts
@@ -23,21 +23,48 @@ export function getAvailableWords(
   level: Level,
   collectedTools: string[],
 ): VocabItem[] {
-  const enabledVocab = vocab.filter((word) => word.enabled);
+  let availableVocab = vocab.filter((word) => word.enabled);
 
   if (level.type === 'puzzle' && level.tools) {
-    return enabledVocab.filter((word) => level.tools?.includes(word.word) && !collectedTools.includes(word.word));
+    availableVocab = availableVocab.filter((word) => level.tools?.includes(word.word) && !collectedTools.includes(word.word));
   }
 
-  return enabledVocab;
+  const { minDifficulty, maxDifficulty } = level;
+
+  if (minDifficulty !== undefined) {
+    availableVocab = availableVocab.filter((word) => word.difficulty >= minDifficulty);
+  }
+
+  if (maxDifficulty !== undefined) {
+    availableVocab = availableVocab.filter((word) => word.difficulty <= maxDifficulty);
+  }
+
+  return availableVocab;
+}
+
+export function selectWord(
+  availableWords: VocabItem[],
+  random: () => number,
+  previousWordId?: string,
+): VocabItem | null {
+  if (availableWords.length === 0) {
+    return null;
+  }
+
+  const candidates = availableWords.length > 1
+    ? availableWords.filter((word) => word.id !== previousWordId)
+    : availableWords;
+  const index = Math.floor(random() * candidates.length);
+
+  return candidates[index] ?? null;
 }
 
 export function isLevelComplete(
   level: Level,
-  progress: { enemyLives: number; collectedTools: string[] },
+  progress: { enemyLives: number; collectedTools: string[]; levelCorrectAnswers: number },
 ): boolean {
   if (level.type === 'boss') {
-    return progress.enemyLives <= 0;
+    return progress.enemyLives <= 0 || progress.levelCorrectAnswers >= level.requiredWords;
   }
 
   return progress.collectedTools.length >= (level.tools?.length || 0);

--- a/web/src/game/gameReducer.test.ts
+++ b/web/src/game/gameReducer.test.ts
@@ -39,6 +39,8 @@ describe('gameReducer', () => {
       enemyLives: 1,
       collectedTools: ['key'],
       correctAnswers: 5,
+      levelCorrectAnswers: 2,
+      skippedWords: 1,
       combo: 3,
       message: 'old message',
     };
@@ -50,6 +52,8 @@ describe('gameReducer', () => {
       enemyLives: 4,
       collectedTools: [],
       correctAnswers: 0,
+      levelCorrectAnswers: 0,
+      skippedWords: 0,
       combo: 0,
       message: '',
     });
@@ -63,6 +67,7 @@ describe('gameReducer', () => {
       score: 10,
       combo: 1,
       correctAnswers: 2,
+      levelCorrectAnswers: 1,
     };
 
     expect(
@@ -77,7 +82,67 @@ describe('gameReducer', () => {
       showEffect: true,
       isBossShaking: true,
       correctAnswers: 3,
-      message: '太棒了! 對怪物造成 2 點傷害!',
+      levelCorrectAnswers: 2,
+      message: '太棒了! +40 分，對怪物造成 2 點傷害!',
+    });
+  });
+
+  it('resets the current level progress when moving to the next level', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      currentLevel: 0,
+      levelCorrectAnswers: 1,
+      skippedWords: 2,
+    };
+
+    expect(gameReducer(state, { type: 'NEXT_LEVEL', payload: { from: 'boss' } })).toMatchObject({
+      currentLevel: 1,
+      levelCorrectAnswers: 0,
+      skippedWords: 0,
+      message: '目標完成! 進入下一關!',
+    });
+  });
+
+  it('makes skipping a meaningful choice by clearing combo, tracking skips, and applying a small score penalty', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      score: 12,
+      combo: 3,
+      skippedWords: 1,
+    };
+
+    expect(gameReducer(state, { type: 'SKIP_WORD' })).toMatchObject({
+      score: 7,
+      combo: 0,
+      skippedWords: 2,
+      message: '已跳過這題：扣 5 分並失去連擊。',
+    });
+  });
+
+  it('does not let skip penalties push score below zero', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      score: 3,
+      combo: 1,
+    };
+
+    expect(gameReducer(state, { type: 'SKIP_WORD' })).toMatchObject({
+      score: 0,
+      combo: 0,
+    });
+  });
+
+  it('explains mistakes without subtracting score', () => {
+    const state = {
+      ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      score: 12,
+      combo: 2,
+    };
+
+    expect(gameReducer(state, { type: 'HANDLE_INCORRECT_ANSWER' })).toMatchObject({
+      score: 12,
+      combo: 0,
+      message: '再試一次! 連擊歸零，但不扣分。',
     });
   });
 

--- a/web/src/game/gameReducer.ts
+++ b/web/src/game/gameReducer.ts
@@ -16,6 +16,8 @@ export interface AppState {
   practiceMode: 'voice' | 'spelling';
   gameState: GameState;
   correctAnswers: number;
+  levelCorrectAnswers: number;
+  skippedWords: number;
   showEffect: boolean;
   combo: number;
   showHint: boolean;
@@ -44,6 +46,7 @@ export type AppAction =
   | { type: 'RESET_EFFECTS' };
 
 export const POINTS_PER_PUZZLE = 10;
+export const SKIP_PENALTY = 5;
 
 interface InitialStateOptions {
   levels?: Level[];
@@ -67,6 +70,8 @@ export function createInitialState({
     practiceMode: 'voice',
     gameState: 'menu',
     correctAnswers: 0,
+    levelCorrectAnswers: 0,
+    skippedWords: 0,
     showEffect: false,
     combo: 0,
     showHint: false,
@@ -90,6 +95,8 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
         enemyLives: state.levels[0]?.enemyLives || 5,
         collectedTools: [],
         correctAnswers: 0,
+        levelCorrectAnswers: 0,
+        skippedWords: 0,
         combo: 0,
         message: '',
       };
@@ -111,9 +118,10 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
         combo: state.combo + 1,
         showEffect: true,
         enemyLives: newEnemyLives,
-        message: `太棒了! 對怪物造成 ${damage} 點傷害!`,
+        message: `太棒了! +${points} 分，對怪物造成 ${damage} 點傷害!`,
         isBossShaking: true,
         correctAnswers: state.correctAnswers + 1,
+        levelCorrectAnswers: state.levelCorrectAnswers + 1,
       };
     }
     case 'HANDLE_PUZZLE_CORRECT': {
@@ -127,10 +135,11 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
         collectedTools: newCollectedTools,
         message: `獲得了 ${action.payload.word}!`,
         correctAnswers: state.correctAnswers + 1,
+        levelCorrectAnswers: state.levelCorrectAnswers + 1,
       };
     }
     case 'HANDLE_INCORRECT_ANSWER':
-      return { ...state, message: '再試一次!', combo: 0 };
+      return { ...state, message: '再試一次! 連擊歸零，但不扣分。', combo: 0 };
     case 'NEXT_LEVEL': {
       const nextLevelIndex = state.currentLevel + 1;
 
@@ -140,13 +149,15 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
 
       const message = action.payload?.from === 'puzzle'
         ? '謎題解開! 進入下一關!'
-        : '關卡完成! 進入下一關!';
+        : '目標完成! 進入下一關!';
 
       return {
         ...state,
         currentLevel: nextLevelIndex,
         enemyLives: state.levels[nextLevelIndex]?.enemyLives || 5,
         collectedTools: [],
+        levelCorrectAnswers: 0,
+        skippedWords: 0,
         message,
       };
     }
@@ -163,7 +174,13 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
     case 'SET_RECOGNITION_LANG':
       return { ...state, recognitionLang: action.payload };
     case 'SKIP_WORD':
-      return { ...state, combo: 0 };
+      return {
+        ...state,
+        score: Math.max(0, state.score - SKIP_PENALTY),
+        combo: 0,
+        skippedWords: state.skippedWords + 1,
+        message: `已跳過這題：扣 ${SKIP_PENALTY} 分並失去連擊。`,
+      };
     case 'SET_COMBO':
       return { ...state, combo: action.payload };
     case 'RESET_EFFECTS':


### PR DESCRIPTION
## Summary
- Use boss `requiredWords` as a visible per-level objective and completion condition
- Add per-level difficulty constraints and word selection that avoids immediate repeats when alternatives exist
- Make skip a meaningful choice with a small score penalty, skip count, combo reset, and clear feedback
- Clarify mistake/reward feedback so players can understand score, combo, and progression outcomes
- Address review feedback by falling back to enabled words when difficulty filters would empty a level and showing the boss HP win condition in the objective

## Verification
- `npm test -- --runInBand` (59 passed)
- `npm run build`
- GitHub Actions `validate` passed on `c2eca6d`

Closes #58