### PR TITLE
[codex] Add guided voice practice review flow

### DIFF
--- a/docs/superpowers/plans/2026-05-31-voice-practice-flow.md
+++ b/docs/superpowers/plans/2026-05-31-voice-practice-flow.md
@@ -1,0 +1,167 @@
+# Voice Practice Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make voice input a guided pronunciation practice flow where final recognition results are reviewed, retried, or confirmed before gameplay submission.
+
+**Architecture:** Keep the gameplay reducer unchanged for this first PR and add the review phase at the `App` interaction boundary. `useSpeechRecognition` remains responsible for browser recognition lifecycle; `App` owns whether a final transcript is accepted into the game.
+
+**Tech Stack:** React 18, TypeScript, Jest, Testing Library, Web Speech API mock.
+
+---
+
+### Task 1: App Voice Review Flow
+
+**Files:**
+- Modify: `web/src/App.test.tsx`
+- Modify: `web/src/App.tsx`
+
+- [x] **Step 1: Write failing tests for review-first voice submission**
+
+```tsx
+it('reviews final speech recognition results before submitting them', async () => {
+  render(<App initialVocab={defaultTestVocab} />);
+  fireEvent.click(screen.getByText('開始遊戲'));
+
+  await waitFor(() => {
+    expect(screen.getByText('關卡 1')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText('點擊說話'));
+  const recognition = MockSpeechRecognition.instances[0];
+
+  act(() => {
+    recognition.onstart?.();
+    recognition.onresult?.({
+      resultIndex: 0,
+      results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
+    });
+  });
+
+  expect(screen.getByText('聽到：apple')).toBeInTheDocument();
+  expect(screen.getByText('目標：apple')).toBeInTheDocument();
+  expect(screen.getByText('分數: 0')).toBeInTheDocument();
+  expect(screen.queryByText(/太棒了!/)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /確認送出/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/太棒了! \+10 分，對怪物造成 1 點傷害!/)).toBeInTheDocument();
+  });
+  expect(screen.getByText('分數: 10')).toBeInTheDocument();
+});
+```
+
+- [x] **Step 2: Run the focused failing test**
+
+Run: `npm test -- App.test.tsx --runInBand`
+Expected: FAIL because `聽到：apple` and `確認送出` do not exist, and speech currently submits immediately.
+
+- [x] **Step 3: Implement minimal review state in App**
+
+Add local state:
+
+```tsx
+type VoiceReviewResult = {
+  heardText: string;
+  targetWord: string;
+  isMatch: boolean;
+};
+```
+
+Use `useState<VoiceReviewResult | null>(null)`. In `onResult`, when the game is playing in voice mode and there is no pending review, set review state instead of calling `handleSubmitRef.current`.
+
+- [x] **Step 4: Render review controls**
+
+In the voice UI, render:
+
+```tsx
+{voiceReview && (
+  <div className="eq-voice-review" role="status" aria-live="polite">
+    <p>聽到：{voiceReview.heardText}</p>
+    <p>目標：{voiceReview.targetWord}</p>
+    <p>{voiceReview.isMatch ? '聽起來很接近，確認後發動攻擊。' : '還沒聽準，可以重試一次。'}</p>
+    <QuestButton onClick={retryVoiceReview}>重試語音</QuestButton>
+    <QuestButton onClick={confirmVoiceReview}>確認送出</QuestButton>
+  </div>
+)}
+```
+
+- [x] **Step 5: Run the focused test to verify green**
+
+Run: `npm test -- App.test.tsx --runInBand`
+Expected: PASS for the updated App tests.
+
+### Task 2: Retry, Late Result, and Error Recovery
+
+**Files:**
+- Modify: `web/src/App.test.tsx`
+- Modify: `web/src/App.tsx`
+
+- [x] **Step 1: Write failing tests for retry and late-result safety**
+
+Add tests that assert:
+- Clicking `重試語音` clears the review result and starts listening again.
+- A second final speech event while the first result is pending review does not replace the pending transcript or submit damage.
+- Switching to spelling mode clears pending voice review.
+
+- [x] **Step 2: Run the focused failing tests**
+
+Run: `npm test -- App.test.tsx --runInBand`
+Expected: FAIL because retry and late-result guards are not implemented yet.
+
+- [x] **Step 3: Implement retry and stale-result guards**
+
+Use refs for current acceptance and pending review:
+
+```tsx
+const voiceReviewRef = useRef<VoiceReviewResult | null>(null);
+voiceReviewRef.current = voiceReview;
+acceptSpeechResultsRef.current = gameState === 'playing' && practiceMode === 'voice' && !voiceReview;
+```
+
+Implement `retryVoiceReview` to clear review, reset transcript, clear speech error, and call `speech.start(recognitionLang)`. Clear review when changing word, changing practice mode, skipping, or confirming.
+
+- [x] **Step 4: Run focused tests**
+
+Run: `npm test -- App.test.tsx --runInBand`
+Expected: PASS.
+
+### Task 3: Verification and PR
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-05-31-voice-practice-flow.md`
+- Modify: changed source/tests from prior tasks
+
+- [x] **Step 1: Run full tests**
+
+Run: `npm test -- --runInBand`
+Expected: all Jest suites pass.
+
+- [x] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: TypeScript and esbuild finish with exit code 0.
+
+- [x] **Step 3: Check whitespace**
+
+Run: `git diff --check`
+Expected: no whitespace errors.
+
+- [x] **Step 4: Review diff**
+
+Run: `git diff --stat main...HEAD` and inspect the changed files for accidental scope creep.
+
+- [ ] **Step 5: Commit and open PR**
+
+Commit message:
+
+```text
+feat: add guided voice practice review flow
+
+Constraint: Keep gameplay reducer unchanged for first voice-flow PR
+Confidence: high
+Scope-risk: moderate
+```
+
+Open a PR to `main` referencing issue `#56`.

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -288,6 +288,32 @@
         background: rgba(255, 255, 255, 0.44);
       }
 
+      .eq-voice-review {
+        min-height: 136px;
+        display: grid;
+        justify-items: center;
+        gap: 8px;
+        padding: 14px;
+        border: 1px solid rgba(47, 114, 136, 0.25);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.56);
+        text-align: center;
+      }
+
+      .eq-voice-review p {
+        margin: 0;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+      }
+
+      .eq-voice-review__actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        margin-top: 4px;
+      }
+
       .eq-control-row {
         display: flex;
         flex-wrap: wrap;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -441,7 +441,7 @@ describe('<App />', () => {
     expect(screen.getByText('攻擊!')).toBeInTheDocument();
   });
 
-  it('shows a user-facing speech recognition error and switches to spelling mode', async () => {
+  it('keeps transient speech recognition errors in voice mode with a retry action', async () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));
 
@@ -458,9 +458,21 @@ describe('<App />', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('語音辨識暫時無法連線，已切換到拼字模式。')).toBeInTheDocument();
+      expect(screen.getByText('語音辨識暫時無法連線，請重試語音。')).toBeInTheDocument();
     });
-    expect(screen.getByPlaceholderText('輸入英文單字')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('輸入英文單字')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /切換到拼字模式/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /重試語音/i }));
+    expect(recognition.start).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      recognition.onstart?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('語音辨識暫時無法連線，請重試語音。')).not.toBeInTheDocument();
+    });
   });
 
   it('explains microphone permission errors without exposing raw browser codes', async () => {
@@ -486,7 +498,7 @@ describe('<App />', () => {
     expect(screen.getByPlaceholderText('輸入英文單字')).toBeInTheDocument();
   });
 
-  it('allows retrying voice mode after a transient speech recognition error', async () => {
+  it('can still switch to spelling mode after a transient speech recognition error', async () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));
 
@@ -503,32 +515,18 @@ describe('<App />', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('語音辨識暫時無法連線，已切換到拼字模式。')).toBeInTheDocument();
+      expect(screen.getByText('語音辨識暫時無法連線，請重試語音。')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到拼字模式/i }));
+
+    await waitFor(() => {
       expect(screen.getByPlaceholderText('輸入英文單字')).toBeInTheDocument();
     });
-
-    const voiceModeButton = screen.getByRole('button', { name: /切換到語音模式/i });
-    expect(voiceModeButton).not.toBeDisabled();
-
-    fireEvent.click(voiceModeButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('點擊說話')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText('點擊說話'));
-    expect(recognition.start).toHaveBeenCalledTimes(2);
-
-    act(() => {
-      recognition.onstart?.();
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByText('語音辨識暫時無法連線，已切換到拼字模式。')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText('語音辨識暫時無法連線，請重試語音。')).not.toBeInTheDocument();
   });
 
-  it('submits final speech recognition results immediately while still listening', async () => {
+  it('reviews final speech recognition results before submitting them', async () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));
 
@@ -543,14 +541,152 @@ describe('<App />', () => {
       recognition.onstart?.();
       recognition.onresult?.({
         resultIndex: 0,
-        results: [{ isFinal: true, 0: { transcript: 'apple' } }],
+        results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
       });
     });
+
+    expect(screen.getByText('聽到：apple')).toBeInTheDocument();
+    expect(screen.getByText('目標：apple')).toBeInTheDocument();
+    expect(screen.getByText('分數: 0')).toBeInTheDocument();
+    expect(screen.queryByText(/太棒了!/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /確認送出/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/太棒了! \+10 分，對怪物造成 1 點傷害!/)).toBeInTheDocument();
     });
-    expect(screen.getByText('聆聽中...')).toBeInTheDocument();
+    expect(screen.getByText('分數: 10')).toBeInTheDocument();
+  });
+
+  it('retries a pending voice review without submitting the previous result', async () => {
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('點擊說話'));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    act(() => {
+      recognition.onstart?.();
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' sword ' } }],
+      });
+    });
+
+    expect(screen.getByText('聽到：sword')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /重試語音/i }));
+
+    expect(screen.queryByText('聽到：sword')).not.toBeInTheDocument();
+    expect(screen.getByText('分數: 0')).toBeInTheDocument();
+
+    act(() => {
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
+      });
+    });
+
+    expect(screen.getByText('聽到：apple')).toBeInTheDocument();
+  });
+
+  it('keeps the first pending voice review when later recognition results arrive before confirmation', async () => {
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('點擊說話'));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    act(() => {
+      recognition.onstart?.();
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' sword ' } }],
+      });
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
+      });
+    });
+
+    expect(screen.getByText('聽到：sword')).toBeInTheDocument();
+    expect(screen.queryByText('聽到：apple')).not.toBeInTheDocument();
+    expect(screen.getByText('分數: 0')).toBeInTheDocument();
+  });
+
+  it('clears a pending voice review when switching out of voice mode', async () => {
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('點擊說話'));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    act(() => {
+      recognition.onstart?.();
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' sword ' } }],
+      });
+    });
+
+    expect(screen.getByText('聽到：sword')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到拼字模式/i }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('輸入英文單字')).toBeInTheDocument();
+    });
+
+    act(() => {
+      recognition.onend?.();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到語音模式/i }));
+
+    expect(screen.getByRole('button', { name: /切換到拼字模式/i })).toBeInTheDocument();
+    expect(screen.queryByText('聽到：sword')).not.toBeInTheDocument();
+  });
+
+  it('clears a pending voice review when skipping to another word', async () => {
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('點擊說話'));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    act(() => {
+      recognition.onstart?.();
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' banana ' } }],
+      });
+    });
+
+    expect(screen.getByText('聽到：banana')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /skip word/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('⚔️')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('聽到：banana')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /確認送出/i })).not.toBeInTheDocument();
   });
 
   it('ignores late speech recognition results after switching to spelling mode', async () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -558,6 +558,43 @@ describe('<App />', () => {
     expect(screen.getByText('分數: 10')).toBeInTheDocument();
   });
 
+  it('ignores duplicate speech results after confirming a correct voice review', async () => {
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('點擊說話'));
+    const recognition = MockSpeechRecognition.instances[0];
+
+    act(() => {
+      recognition.onstart?.();
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /確認送出/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('分數: 10')).toBeInTheDocument();
+    });
+
+    act(() => {
+      recognition.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: ' apple ' } }],
+      });
+    });
+
+    expect(screen.queryByText('聽到：apple')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /確認送出/i })).not.toBeInTheDocument();
+    expect(screen.getByText('分數: 10')).toBeInTheDocument();
+  });
+
   it('retries a pending voice review without submitting the previous result', async () => {
     render(<App initialVocab={defaultTestVocab} />);
     fireEvent.click(screen.getByText('開始遊戲'));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,8 @@ const STORAGE_KEY_LANG = "echoquest_lang_v1";
 const DEFAULT_VOCAB_BY_ID = new Map(defaultInitialVocab.map((item) => [item.id, item]));
 const DEFAULT_VOCAB_BY_WORD = new Map(defaultInitialVocab.map((item) => [item.word, item]));
 const BLOCKING_SPEECH_ERRORS = new Set(['not-allowed', 'service-not-allowed', 'audio-capture']);
+const ANSWER_EFFECT_RESET_DELAY_MS = 500;
+const ANSWER_ADVANCE_DELAY_MS = 1500;
 
 function isBlockingSpeechError(error: string): boolean {
   return BLOCKING_SPEECH_ERRORS.has(error);
@@ -90,6 +92,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   }));
   const [voiceReview, setVoiceReview] = useState<VoiceReviewResult | null>(null);
   const voiceReviewRef = useRef<VoiceReviewResult | null>(null);
+  const voiceSubmissionLockedRef = useRef(false);
   const updateVoiceReview = (nextReview: VoiceReviewResult | null) => {
     voiceReviewRef.current = nextReview;
     setVoiceReview(nextReview);
@@ -118,7 +121,10 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
 
   const handleSubmitRef = useRef<(submittedText: string) => void>(() => {});
   const acceptSpeechResultsRef = useRef(false);
-  acceptSpeechResultsRef.current = gameState === 'playing' && practiceMode === 'voice' && !voiceReviewRef.current;
+  acceptSpeechResultsRef.current = gameState === 'playing'
+    && practiceMode === 'voice'
+    && !voiceReviewRef.current
+    && !voiceSubmissionLockedRef.current;
   const speech = useSpeechRecognition({
     autoRestart: gameState === 'playing' && practiceMode === 'voice',
     onResult: (result) => {
@@ -201,7 +207,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     correctAnswersRef.current = correctAnswers;
 
     // Reset visual effects after a short delay
-    const effectTimer = setTimeout(() => dispatch({ type: 'RESET_EFFECTS' }), 500);
+    const effectTimer = setTimeout(() => dispatch({ type: 'RESET_EFFECTS' }), ANSWER_EFFECT_RESET_DELAY_MS);
 
     const level = levels[currentLevel];
     const levelComplete = isLevelComplete(level, { enemyLives, collectedTools, levelCorrectAnswers });
@@ -217,7 +223,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
         } else {
             selectNewWord(); // Not level complete, so just get the next word.
         }
-    }, 1500);
+    }, ANSWER_ADVANCE_DELAY_MS);
 
     return () => {
         clearTimeout(effectTimer);
@@ -280,12 +286,14 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
       return;
     }
 
-    const { heardText } = voiceReview;
+    const { heardText, isMatch } = voiceReview;
     updateVoiceReview(null);
+    voiceSubmissionLockedRef.current = isMatch;
     handleSubmit(heardText);
   };
 
   const retryVoiceReview = () => {
+    voiceSubmissionLockedRef.current = false;
     updateVoiceReview(null);
     speech.resetTranscript();
     speech.clearError();
@@ -298,6 +306,18 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   useEffect(() => {
     handleSubmitRef.current = handleSubmit;
   });
+
+  useEffect(() => {
+    if (!voiceSubmissionLockedRef.current) {
+      return;
+    }
+
+    const unlockTimer = setTimeout(() => {
+      voiceSubmissionLockedRef.current = false;
+    }, ANSWER_ADVANCE_DELAY_MS);
+
+    return () => clearTimeout(unlockTimer);
+  }, [correctAnswers]);
 
   useEffect(() => {
     if (!speech.isSupported && practiceMode === 'voice') {
@@ -316,6 +336,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
       speech.stop();
     }
     if (practiceMode !== 'voice') {
+      voiceSubmissionLockedRef.current = false;
       speech.resetTranscript();
       updateVoiceReview(null);
     }
@@ -334,6 +355,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   }, [practiceMode, recognitionLang, speech.listening, speech.start]);
 
   const handleSkip = () => {
+    voiceSubmissionLockedRef.current = false;
     updateVoiceReview(null);
     speech.resetTranscript();
     dispatch({ type: 'SKIP_WORD' });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useReducer } from 'react';
+import React, { useEffect, useMemo, useRef, useReducer, useState } from 'react';
 import { Sword, Heart, Mic, MicOff, Volume2, Star, Zap, Trophy, Skull, Sparkles, Settings, HelpCircle, SkipForward, Globe } from 'lucide-react';
 import { VocabManager } from './components/VocabManager';
 import { IconButton, Panel, QuestButton, ScreenShell, StatBadge } from './components/QuestFrame';
@@ -15,20 +15,25 @@ const STORAGE_KEY_VOCAB = "echoquest_vocab_v1";
 const STORAGE_KEY_LANG = "echoquest_lang_v1";
 const DEFAULT_VOCAB_BY_ID = new Map(defaultInitialVocab.map((item) => [item.id, item]));
 const DEFAULT_VOCAB_BY_WORD = new Map(defaultInitialVocab.map((item) => [item.word, item]));
+const BLOCKING_SPEECH_ERRORS = new Set(['not-allowed', 'service-not-allowed', 'audio-capture']);
+
+function isBlockingSpeechError(error: string): boolean {
+  return BLOCKING_SPEECH_ERRORS.has(error);
+}
 
 function getSpeechErrorMessage(error: string): string {
   switch (error) {
     case 'not-allowed':
     case 'service-not-allowed':
       return '麥克風權限被阻擋，已切換到拼字模式。請允許麥克風後再試。';
-    case 'network':
-      return '語音辨識暫時無法連線，已切換到拼字模式。';
-    case 'no-speech':
-      return '沒有聽到聲音，已切換到拼字模式。';
     case 'audio-capture':
       return '找不到可用的麥克風，已切換到拼字模式。';
+    case 'network':
+      return '語音辨識暫時無法連線，請重試語音。';
+    case 'no-speech':
+      return '沒有聽到聲音，請再說一次。';
     default:
-      return `語音辨識暫時無法使用，已切換到拼字模式。 (${error})`;
+      return `語音辨識暫時無法使用，請重試語音。 (${error})`;
   }
 }
 
@@ -72,11 +77,23 @@ interface AppProps {
     initialLevels?: Level[];
 }
 
+type VoiceReviewResult = {
+  heardText: string;
+  targetWord: string;
+  isMatch: boolean;
+};
+
 const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels = defaultLevels }) => {
   const [state, dispatch] = useReducer(gameReducer, createInitialState({
     levels: initialLevels,
     recognitionLang: loadLangFromStorage(),
   }));
+  const [voiceReview, setVoiceReview] = useState<VoiceReviewResult | null>(null);
+  const voiceReviewRef = useRef<VoiceReviewResult | null>(null);
+  const updateVoiceReview = (nextReview: VoiceReviewResult | null) => {
+    voiceReviewRef.current = nextReview;
+    setVoiceReview(nextReview);
+  };
   const {
     vocab,
     levels,
@@ -101,14 +118,27 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
 
   const handleSubmitRef = useRef<(submittedText: string) => void>(() => {});
   const acceptSpeechResultsRef = useRef(false);
-  acceptSpeechResultsRef.current = gameState === 'playing' && practiceMode === 'voice';
+  acceptSpeechResultsRef.current = gameState === 'playing' && practiceMode === 'voice' && !voiceReviewRef.current;
   const speech = useSpeechRecognition({
     autoRestart: gameState === 'playing' && practiceMode === 'voice',
     onResult: (result) => {
-      if (!acceptSpeechResultsRef.current) {
+      if (!acceptSpeechResultsRef.current || voiceReviewRef.current) {
         return;
       }
-      handleSubmitRef.current(result);
+      if (!currentWord) {
+        return;
+      }
+
+      const heardText = result.trim();
+      if (!heardText) {
+        return;
+      }
+
+      updateVoiceReview({
+        heardText,
+        targetWord: currentWord.word,
+        isMatch: isAnswerCorrect(heardText, currentWord),
+      });
     },
   });
 
@@ -245,6 +275,26 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     dispatch({ type: 'SET_USER_INPUT', payload: '' });
   };
 
+  const confirmVoiceReview = () => {
+    if (!voiceReview) {
+      return;
+    }
+
+    const { heardText } = voiceReview;
+    updateVoiceReview(null);
+    handleSubmit(heardText);
+  };
+
+  const retryVoiceReview = () => {
+    updateVoiceReview(null);
+    speech.resetTranscript();
+    speech.clearError();
+
+    if (practiceMode === 'voice' && !speech.listening) {
+      speech.start(recognitionLang);
+    }
+  };
+
   useEffect(() => {
     handleSubmitRef.current = handleSubmit;
   });
@@ -256,7 +306,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   }, [practiceMode, speech.isSupported]);
 
   useEffect(() => {
-    if (speech.error && practiceMode === 'voice') {
+    if (speech.error && practiceMode === 'voice' && isBlockingSpeechError(speech.error)) {
       dispatch({ type: 'SET_PRACTICE_MODE', payload: 'spelling' });
     }
   }, [practiceMode, speech.error]);
@@ -267,6 +317,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     }
     if (practiceMode !== 'voice') {
       speech.resetTranscript();
+      updateVoiceReview(null);
     }
   }, [practiceMode, speech.listening, speech.resetTranscript, speech.stop]);
 
@@ -283,6 +334,8 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   }, [practiceMode, recognitionLang, speech.listening, speech.start]);
 
   const handleSkip = () => {
+    updateVoiceReview(null);
+    speech.resetTranscript();
     dispatch({ type: 'SKIP_WORD' });
     selectNewWord();
   };
@@ -377,6 +430,32 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
                     </p>
                   </div>
 
+                  {voiceReview && practiceMode === 'voice' && (
+                    <div className="eq-voice-review w-full" role="status" aria-live="polite">
+                      <p className="text-lg font-extrabold text-[color:var(--eq-river)]">聽到：{voiceReview.heardText}</p>
+                      <p className="text-sm font-bold text-[color:var(--eq-muted)]">目標：{voiceReview.targetWord}</p>
+                      <p className="text-sm text-[color:var(--eq-muted)]">
+                        {voiceReview.isMatch ? '聽起來很接近，確認後發動攻擊。' : '還沒聽準，可以重試一次。'}
+                      </p>
+                      <div className="eq-voice-review__actions">
+                        <QuestButton
+                          variant="secondary"
+                          onClick={retryVoiceReview}
+                          icon={<Mic className="w-5 h-5" />}
+                        >
+                          重試語音
+                        </QuestButton>
+                        <QuestButton
+                          variant="gold"
+                          onClick={confirmVoiceReview}
+                          icon={<Sword className="w-5 h-5" />}
+                        >
+                          確認送出
+                        </QuestButton>
+                      </div>
+                    </div>
+                  )}
+
                   <div className="eq-control-row">
                     <QuestButton
                       variant={practiceMode === 'voice' ? 'secondary' : 'quiet'}
@@ -385,6 +464,10 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
                           if (practiceMode === 'spelling') {
                             speech.clearError();
                           }
+                          if (practiceMode === 'voice' && speech.error) {
+                            speech.clearError();
+                          }
+                          updateVoiceReview(null);
                           dispatch({ type: 'TOGGLE_PRACTICE_MODE' });
                         }
                       }}
@@ -424,9 +507,20 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
                   </div>
 
                   {speech.error && (
-                    <p className="text-sm text-[color:var(--eq-ruby)] text-center" role="alert">
-                      {getSpeechErrorMessage(speech.error)}
-                    </p>
+                    <div className="flex flex-col items-center gap-3" role="alert">
+                      <p className="text-sm text-[color:var(--eq-ruby)] text-center">
+                        {getSpeechErrorMessage(speech.error)}
+                      </p>
+                      {practiceMode === 'voice' && !isBlockingSpeechError(speech.error) && (
+                        <QuestButton
+                          variant="secondary"
+                          onClick={retryVoiceReview}
+                          icon={<Mic className="w-5 h-5" />}
+                        >
+                          重試語音
+                        </QuestButton>
+                      )}
+                    </div>
                   )}
                   {!speech.isSupported && (
                     <p className="text-sm text-[color:var(--eq-muted)] text-center" role="alert">


### PR DESCRIPTION
## Summary
- Add a guided voice review step so final speech recognition results show the heard transcript and target word before gameplay submission.
- Add retry and confirm actions, with guards for late recognition results, duplicate post-confirm results, mode switches, and skipped words.
- Keep transient speech errors in voice mode with a retry action while preserving spelling fallback for blocked microphone access.
- Add review-flow CSS so the confirmation panel stacks cleanly in the game UI.

Refs #56

## Validation
- `npm test -- --runInBand` (68 passed)
- `npm run build`
- `git diff --check`
- Browser sanity check on built `dist/index.html` with mocked SpeechRecognition review state
- GitHub Actions `validate` success on run #67