### PR TITLE
Refactor App into focused modules

### DIFF
--- a/docs/superpowers/plans/2026-06-01-app-module-refactor.md
+++ b/docs/superpowers/plans/2026-06-01-app-module-refactor.md
@@ -1,0 +1,235 @@
+# App Module Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `web/src/App.tsx` into focused persistence, component, and screen modules without changing gameplay behavior.
+
+**Architecture:** `App.tsx` remains the reducer/effect coordinator and delegates persistence to `web/src/persistence/vocabStorage.ts` and rendering to presentational screen components. Screen components receive state snapshots and callbacks; they do not read storage or dispatch actions directly.
+
+**Tech Stack:** React 18, TypeScript, Jest, Testing Library, esbuild.
+
+---
+
+## File Structure
+
+- Create: `web/src/persistence/vocabStorage.ts`
+  - Owns vocabulary and language localStorage keys, load/save helpers, and default artwork hydration.
+- Create: `web/src/persistence/vocabStorage.test.ts`
+  - Covers storage parsing fallback, language defaults, save/load round trips, and default artwork hydration.
+- Create: `web/src/components/LanguageSelector.tsx`
+  - Owns the existing recognition language select UI.
+- Create: `web/src/components/LanguageSelector.test.tsx`
+  - Covers menu and compact selector rendering plus change callback.
+- Create: `web/src/screens/MenuScreen.tsx`
+  - Presentational main menu.
+- Create: `web/src/screens/VictoryScreen.tsx`
+  - Presentational victory screen.
+- Create: `web/src/screens/GameScreen.tsx`
+  - Presentational gameplay screen.
+- Modify: `web/src/App.tsx`
+  - Remove storage helpers, `LanguageSelector`, and render functions.
+  - Pass typed props/callbacks into screen components.
+
+## Task 1: Baseline Verification
+
+- [ ] **Step 1: Confirm clean branch**
+
+Run: `git status --short --branch`
+
+Expected: current branch is `codex/app-module-refactor`; no uncommitted source changes except the plan if it is not yet committed.
+
+- [ ] **Step 2: Run current test suite**
+
+Run from `web`: `npm test -- --runInBand`
+
+Expected: all current tests pass before refactoring begins.
+
+## Task 2: Extract Storage Helpers With TDD
+
+**Files:**
+- Create: `web/src/persistence/vocabStorage.test.ts`
+- Create: `web/src/persistence/vocabStorage.ts`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Write the failing storage test**
+
+Add tests that import these future exports:
+
+```ts
+import {
+  STORAGE_KEY_LANG,
+  STORAGE_KEY_VOCAB,
+  hydrateDefaultVocabArtwork,
+  loadLangFromStorage,
+  loadVocabFromStorage,
+  saveLangToStorage,
+  saveVocabToStorage,
+} from './vocabStorage';
+```
+
+Cover these behaviors:
+
+- `hydrateDefaultVocabArtwork` restores bundled `imageSrc` when a stored default word has no image data.
+- `loadVocabFromStorage` returns an empty list for invalid JSON.
+- `saveVocabToStorage` and `loadVocabFromStorage` round-trip a custom item.
+- `loadLangFromStorage` defaults to `en-US`; `saveLangToStorage` persists a selected language.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/persistence/vocabStorage.test.ts --runInBand`
+
+Expected: FAIL because `./vocabStorage` does not exist.
+
+- [ ] **Step 3: Implement minimal storage module**
+
+Move the storage constants and helper logic out of `App.tsx` into `web/src/persistence/vocabStorage.ts`. Keep key names exactly:
+
+```ts
+export const STORAGE_KEY_VOCAB = 'echoquest_vocab_v1';
+export const STORAGE_KEY_LANG = 'echoquest_lang_v1';
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run from `web`: `npm test -- src/persistence/vocabStorage.test.ts --runInBand`
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire App to storage module**
+
+Import `loadVocabFromStorage`, `saveVocabToStorage`, `loadLangFromStorage`, and `saveLangToStorage` in `App.tsx`; remove the local helper definitions.
+
+- [ ] **Step 6: Run App regression tests**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: PASS, including the bundled artwork hydration test.
+
+## Task 3: Extract LanguageSelector With TDD
+
+**Files:**
+- Create: `web/src/components/LanguageSelector.test.tsx`
+- Create: `web/src/components/LanguageSelector.tsx`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Test that the menu variant renders the globe-enhanced selector with `aria-label="Select recognition language"` and calls `onLangChange('en-GB')` when changed. Test that the compact variant renders the same options without requiring menu layout.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/components/LanguageSelector.test.tsx --runInBand`
+
+Expected: FAIL because `LanguageSelector.tsx` does not exist.
+
+- [ ] **Step 3: Move LanguageSelector**
+
+Create `web/src/components/LanguageSelector.tsx` with the exact language options currently embedded in `App.tsx`. Remove the embedded component from `App.tsx` and import the new component.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run from `web`: `npm test -- src/components/LanguageSelector.test.tsx --runInBand`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run App regression tests**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: PASS.
+
+## Task 4: Extract Menu and Victory Screens
+
+**Files:**
+- Create: `web/src/screens/MenuScreen.tsx`
+- Create: `web/src/screens/VictoryScreen.tsx`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Move main menu JSX**
+
+Create `MenuScreen` with props:
+
+```ts
+type MenuScreenProps = {
+  recognitionLang: string;
+  speechSupported: boolean;
+  message: string;
+  onRecognitionLangChange: (lang: string) => void;
+  onStartGame: () => void;
+  onOpenVocabManagement: () => void;
+};
+```
+
+- [ ] **Step 2: Move victory JSX**
+
+Create `VictoryScreen` with props:
+
+```ts
+type VictoryScreenProps = {
+  score: number;
+  correctAnswers: number;
+  onStartGame: () => void;
+};
+```
+
+- [ ] **Step 3: Wire App switch**
+
+Replace `renderMenu()` and `renderVictory()` calls with `<MenuScreen />` and `<VictoryScreen />`.
+
+- [ ] **Step 4: Run App regression tests**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: PASS for menu and victory tests.
+
+## Task 5: Extract GameScreen
+
+**Files:**
+- Create: `web/src/screens/GameScreen.tsx`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Define GameScreen props**
+
+Move the gameplay JSX into `GameScreen`. Use explicit props for state values, speech view model, voice review, and callbacks. Keep the speech review state owned by `App.tsx`.
+
+- [ ] **Step 2: Wire callbacks from App**
+
+Pass callbacks for submit, skip, input change, hint press/release, retry voice review, confirm voice review, mode toggle, listening toggle, and language change.
+
+- [ ] **Step 3: Remove old renderGame function**
+
+Delete `renderGame()` from `App.tsx` and render `<GameScreen />` in the `playing` branch.
+
+- [ ] **Step 4: Run voice and gameplay regression tests**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: PASS for text answer, skip, hint, speech errors, voice review, duplicate speech result, and late speech result tests.
+
+## Task 6: Final Verification and PR
+
+- [ ] **Step 1: Run full tests**
+
+Run from `web`: `npm test -- --runInBand`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run production build**
+
+Run from `web`: `npm run build`
+
+Expected: TypeScript and esbuild complete successfully.
+
+- [ ] **Step 3: Inspect diff**
+
+Run: `git diff --stat` and `git diff --check`
+
+Expected: diff is focused on #55 and has no whitespace errors.
+
+- [ ] **Step 4: Commit implementation**
+
+Commit message: `refactor: split app modules`
+
+- [ ] **Step 5: Push and open PR**
+
+Push branch `codex/app-module-refactor` and open a PR to `main` that closes #55.

--- a/docs/superpowers/specs/2026-06-01-app-module-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-01-app-module-refactor-design.md
@@ -1,0 +1,61 @@
+# App Module Refactor Design
+
+## Context
+
+Issue #55 targets `web/src/App.tsx`, which currently owns persistence, speech review policy, game orchestration, and screen rendering in one file. After PR #66, the speech flow is stable but also makes `App.tsx` harder to change safely. This refactor prepares the project for future learning, animation, vocabulary, and accessibility work without changing gameplay behavior.
+
+## Goals
+
+- Keep the current player-facing behavior, copy, storage keys, visual classes, and reducer actions unchanged.
+- Reduce `App.tsx` to the application orchestration layer: reducer wiring, effects, and screen routing.
+- Move localStorage and default artwork hydration into a focused persistence module.
+- Move reusable UI rendering into focused components for language selection and app screens.
+- Preserve the existing App-level tests as the primary regression safety net and add focused tests for newly exported pure helpers.
+
+## Non-Goals
+
+- No visual redesign, animation changes, gameplay tuning, scoring changes, or new pronunciation feedback.
+- No reducer rewrite and no new state management library.
+- No change to bundled vocabulary, level data, or localStorage key names.
+
+## Architecture
+
+`App.tsx` remains the stateful coordinator. It creates reducer state, connects speech recognition to game submission, persists vocabulary and recognition language, and chooses which screen to render.
+
+Storage logic moves to `web/src/persistence/vocabStorage.ts`. This module exposes vocabulary and language load/save helpers plus default artwork hydration. It depends only on vocabulary data and types, so it can be tested without rendering React.
+
+UI rendering moves out of `App.tsx`:
+
+- `web/src/components/LanguageSelector.tsx` renders the existing recognition language selector.
+- `web/src/screens/MenuScreen.tsx` renders the main menu.
+- `web/src/screens/VictoryScreen.tsx` renders the victory screen.
+- `web/src/screens/GameScreen.tsx` renders the active gameplay screen and receives all required data and callbacks as props.
+
+The screen components remain presentational. They do not dispatch reducer actions directly and do not read from localStorage. `App.tsx` passes callbacks such as `onStartGame`, `onSubmit`, `onSkip`, `onSetUserInput`, `onTogglePracticeMode`, and `onRecognitionLangChange`.
+
+## Data Flow
+
+1. `App.tsx` initializes reducer state with `loadLangFromStorage()`.
+2. On mount, `App.tsx` loads vocabulary through `loadVocabFromStorage()` unless `initialVocab` is provided.
+3. `App.tsx` persists vocabulary and language through storage helpers.
+4. `App.tsx` computes game values such as enabled vocabulary and word selection.
+5. `App.tsx` passes state snapshots and callbacks to screen components.
+6. Screen components emit user intent through callbacks only.
+
+## Speech Flow Boundary
+
+For this PR, speech review policy stays in `App.tsx` unless extracting it is needed to make `GameScreen` props manageable. This keeps the recent #66 behavior close to its existing tests. The active game screen receives a `speech` view model, `voiceReview`, and callbacks for retry, confirm, mode toggle, and listening toggle.
+
+## Testing Strategy
+
+- Keep `web/src/App.test.tsx` as end-to-end regression coverage for menu, gameplay, storage hydration, and speech review behavior.
+- Add `web/src/persistence/vocabStorage.test.ts` before extracting storage helpers.
+- Run the focused new test to verify it fails before implementation.
+- Run `npm test -- --runInBand` and `npm run build` before committing and before opening the PR.
+
+## Acceptance Criteria
+
+- `App.tsx` no longer defines localStorage helpers, `LanguageSelector`, or full screen render functions.
+- Existing UI text, ARIA labels, CSS class names, and storage keys continue to work.
+- The default vocabulary artwork hydration behavior is covered by focused unit tests.
+- Full test suite and production build pass.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,20 +1,17 @@
 import React, { useEffect, useMemo, useRef, useReducer, useState } from 'react';
-import { Sword, Heart, Mic, MicOff, Volume2, Star, Zap, Trophy, Skull, Sparkles, Settings, HelpCircle, SkipForward, Globe } from 'lucide-react';
 import { VocabManager } from './components/VocabManager';
-import { IconButton, Panel, QuestButton, ScreenShell, StatBadge } from './components/QuestFrame';
 import type { VocabItem } from './types/vocab';
 import { initialVocab as defaultInitialVocab } from './data/vocab';
 import { useSpeechRecognition } from './hooks/useSpeechRecognition';
 import { defaultLevels, type Level } from './data/levels';
 import { calculateBossReward, getAvailableWords, isAnswerCorrect, isLevelComplete, selectWord } from './game/gameLogic';
 import { createInitialState, gameReducer } from './game/gameReducer';
+import { loadLangFromStorage, loadVocabFromStorage, saveLangToStorage, saveVocabToStorage } from './persistence/vocabStorage';
+import { GameScreen } from './screens/GameScreen';
+import { MenuScreen } from './screens/MenuScreen';
+import { VictoryScreen } from './screens/VictoryScreen';
 
 
-// LocalStorage Utilities
-const STORAGE_KEY_VOCAB = "echoquest_vocab_v1";
-const STORAGE_KEY_LANG = "echoquest_lang_v1";
-const DEFAULT_VOCAB_BY_ID = new Map(defaultInitialVocab.map((item) => [item.id, item]));
-const DEFAULT_VOCAB_BY_WORD = new Map(defaultInitialVocab.map((item) => [item.word, item]));
 const BLOCKING_SPEECH_ERRORS = new Set(['not-allowed', 'service-not-allowed', 'audio-capture']);
 const ANSWER_EFFECT_RESET_DELAY_MS = 500;
 const ANSWER_ADVANCE_DELAY_MS = 1500;
@@ -37,41 +34,6 @@ function getSpeechErrorMessage(error: string): string {
     default:
       return `語音辨識暫時無法使用，請重試語音。 (${error})`;
   }
-}
-
-function loadVocabFromStorage(): VocabItem[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY_VOCAB);
-    if (!raw) return [];
-    return hydrateDefaultVocabArtwork(JSON.parse(raw));
-  } catch {
-    return [];
-  }
-}
-
-function hydrateDefaultVocabArtwork(items: VocabItem[]): VocabItem[] {
-  return items.map((item) => {
-    if (item.imageSrc || item.imageDataUrl) {
-      return item;
-    }
-
-    const defaultById = DEFAULT_VOCAB_BY_ID.get(item.id);
-    const defaultItem = defaultById?.word === item.word ? defaultById : DEFAULT_VOCAB_BY_WORD.get(item.word);
-
-    return defaultItem?.imageSrc ? { ...item, imageSrc: defaultItem.imageSrc } : item;
-  });
-}
-
-function saveVocabToStorage(items: VocabItem[]) {
-  localStorage.setItem(STORAGE_KEY_VOCAB, JSON.stringify(items));
-}
-
-function loadLangFromStorage(): string {
-    return localStorage.getItem(STORAGE_KEY_LANG) || 'en-US';
-}
-
-function saveLangToStorage(lang: string) {
-    localStorage.setItem(STORAGE_KEY_LANG, lang);
 }
 
 interface AppProps {
@@ -119,7 +81,6 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     recognitionLang,
   } = state;
 
-  const handleSubmitRef = useRef<(submittedText: string) => void>(() => {});
   const acceptSpeechResultsRef = useRef(false);
   acceptSpeechResultsRef.current = gameState === 'playing'
     && practiceMode === 'voice'
@@ -304,10 +265,6 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   };
 
   useEffect(() => {
-    handleSubmitRef.current = handleSubmit;
-  });
-
-  useEffect(() => {
     if (!voiceSubmissionLockedRef.current) {
       return;
     }
@@ -362,340 +319,95 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     selectNewWord();
   };
 
-  const renderGame = () => {
-    const level = levels[currentLevel];
-    const speechUnavailable = !speech.isSupported;
-    const totalEnemyLives = level.enemyLives ?? enemyLives;
-    const objectiveText = level.type === 'puzzle'
-      ? `目標: 收集 ${collectedTools.length}/${level.tools?.length || level.requiredWords} 個工具`
-      : `目標: 答對 ${levelCorrectAnswers}/${level.requiredWords} 個單字，或清空生命值 ${enemyLives}/${totalEnemyLives}`;
-    const currentWordImageSrc = currentWord?.imageDataUrl ?? currentWord?.imageSrc;
-    
-    return (
-      <ScreenShell screen="playing" label="EchoQuest 遊戲進行中">
-        <div className="eq-game-shell">
-          <div className="eq-hud" aria-label="冒險狀態">
-            <StatBadge icon={<Trophy className="w-6 h-6" />} label="得分" value={`分數: ${score}`} tone="gold" />
-            <StatBadge icon={<Zap className="w-6 h-6" />} label="節奏" value={`連擊 x${combo}`} tone="green" />
-            <StatBadge icon={<SkipForward className="w-6 h-6" />} label="選擇" value={`跳過 ${skippedWords} 次`} tone="blue" />
-            <StatBadge icon={<Star className="w-6 h-6" />} label="進度" value={`關卡 ${currentLevel + 1}`} tone="red" />
-          </div>
-
-          <div className="eq-game-grid">
-            <Panel className="eq-level-panel">
-              <p className="text-sm font-extrabold uppercase text-[color:var(--eq-muted)]">Quest Log</p>
-              <h2 className="eq-display eq-level-title">{level.name}</h2>
-              <p className="mt-2 text-[color:var(--eq-muted)]">{level.description}</p>
-              <p className="eq-objective">{objectiveText}</p>
-
-              <div className={`eq-enemy-figure ${isBossShaking ? 'shake' : ''}`}>
-                {level.imageSrc ? (
-                  <img src={level.imageSrc} alt={`${level.name} artwork`} className="eq-enemy-artwork" />
-                ) : (
-                  <span aria-hidden="true">{level.imageEmoji}</span>
-                )}
-              </div>
-
-              {level.type === 'boss' && (
-                <div className="flex justify-center items-center gap-2" aria-label="Boss health">
-                  <Skull className="w-7 h-7 text-[color:var(--eq-rust)]" />
-                  <div className="flex gap-1">
-                    {[...Array(level.enemyLives ?? 0)].map((_, i) => (
-                      <Heart
-                        key={i}
-                        className={`w-7 h-7 ${i < enemyLives ? 'text-[color:var(--eq-rust)]' : 'text-stone-300'}`}
-                        fill={i < enemyLives ? 'currentColor' : 'none'}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {level.type === 'puzzle' && (
-                <div className="flex justify-center items-center gap-2 text-4xl" aria-label="Puzzle progress">
-                  {[...Array(level.tools ? level.tools.length - collectedTools.length : 0)].map((_, i) => (
-                    <span key={i}>🚪</span>
-                  ))}
-                  {[...Array(collectedTools.length)].map((_, i) => (
-                    <span key={i} className="opacity-50">🔑</span>
-                  ))}
-                </div>
-              )}
-            </Panel>
-
-            {currentWord && (
-              <Panel className="eq-challenge-panel">
-                <div className={`eq-word-stage ${showEffect ? 'eq-word-stage--success' : ''}`}>
-                  {currentWordImageSrc ? (
-                    <img src={currentWordImageSrc} alt={currentWord.word} className="eq-word-photo" />
-                  ) : (
-                    <div className="eq-word-image" aria-hidden="true">{currentWord.imageName}</div>
-                  )}
-                  <div className="mt-4 flex justify-center gap-1">
-                    {[...Array(currentWord.difficulty)].map((_, i) => (
-                      <Star key={i} className="w-5 h-5 text-[color:var(--eq-sun)]" fill="currentColor" />
-                    ))}
-                  </div>
-                  <p className="mt-1 text-sm font-bold text-[color:var(--eq-muted)]">難度等級</p>
-                  {showHint && (
-                    <div className="eq-hint-overlay">
-                      <span className="eq-display text-4xl font-extrabold">{currentWord.word}</span>
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex flex-col items-center gap-4">
-                  <div className="eq-transcript w-full">
-                    <p className="text-xl">
-                      <span className="font-extrabold text-[color:var(--eq-river)]">{speech.transcript}</span>
-                      <span className="text-[color:var(--eq-muted)]">{speech.interimTranscript}</span>
-                    </p>
-                  </div>
-
-                  {voiceReview && practiceMode === 'voice' && (
-                    <div className="eq-voice-review w-full" role="status" aria-live="polite">
-                      <p className="text-lg font-extrabold text-[color:var(--eq-river)]">聽到：{voiceReview.heardText}</p>
-                      <p className="text-sm font-bold text-[color:var(--eq-muted)]">目標：{voiceReview.targetWord}</p>
-                      <p className="text-sm text-[color:var(--eq-muted)]">
-                        {voiceReview.isMatch ? '聽起來很接近，確認後發動攻擊。' : '還沒聽準，可以重試一次。'}
-                      </p>
-                      <div className="eq-voice-review__actions">
-                        <QuestButton
-                          variant="secondary"
-                          onClick={retryVoiceReview}
-                          icon={<Mic className="w-5 h-5" />}
-                        >
-                          重試語音
-                        </QuestButton>
-                        <QuestButton
-                          variant="gold"
-                          onClick={confirmVoiceReview}
-                          icon={<Sword className="w-5 h-5" />}
-                        >
-                          確認送出
-                        </QuestButton>
-                      </div>
-                    </div>
-                  )}
-
-                  <div className="eq-control-row">
-                    <QuestButton
-                      variant={practiceMode === 'voice' ? 'secondary' : 'quiet'}
-                      onClick={() => {
-                        if (practiceMode === 'voice' || !speechUnavailable) {
-                          if (practiceMode === 'spelling') {
-                            speech.clearError();
-                          }
-                          if (practiceMode === 'voice' && speech.error) {
-                            speech.clearError();
-                          }
-                          updateVoiceReview(null);
-                          dispatch({ type: 'TOGGLE_PRACTICE_MODE' });
-                        }
-                      }}
-                      aria-label={practiceMode === 'voice' ? '切換到拼字模式' : '切換到語音模式'}
-                      disabled={practiceMode === 'spelling' && speechUnavailable}
-                      icon={practiceMode === 'voice' ? <Mic className="w-5 h-5" /> : <MicOff className="w-5 h-5" />}
-                    >
-                      {practiceMode === 'voice' ? '語音' : '拼字'}
-                    </QuestButton>
-
-                    {practiceMode === 'voice' ? (
-                      <QuestButton
-                        variant={speech.listening ? 'danger' : 'primary'}
-                        onClick={() => {
-                          if (speech.listening) {
-                            speech.stop();
-                          } else {
-                            speech.start(recognitionLang);
-                          }
-                        }}
-                        disabled={speechUnavailable}
-                        icon={<Volume2 className="w-5 h-5" />}
-                      >
-                        {speech.listening ? '聆聽中...' : '點擊說話'}
-                      </QuestButton>
-                    ) : (
-                      <input
-                        type="text"
-                        value={userInput}
-                        onChange={(e) => dispatch({ type: 'SET_USER_INPUT', payload: e.target.value })}
-                        onKeyDown={(e) => e.key === 'Enter' && handleSubmit(userInput)}
-                        placeholder="輸入英文單字"
-                        className="eq-input"
-                      />
-                    )}
-                    <LanguageSelector selectedLang={recognitionLang} onLangChange={(lang) => dispatch({ type: 'SET_RECOGNITION_LANG', payload: lang })} />
-                  </div>
-
-                  {speech.error && (
-                    <div className="flex flex-col items-center gap-3" role="alert">
-                      <p className="text-sm text-[color:var(--eq-ruby)] text-center">
-                        {getSpeechErrorMessage(speech.error)}
-                      </p>
-                      {practiceMode === 'voice' && !isBlockingSpeechError(speech.error) && (
-                        <QuestButton
-                          variant="secondary"
-                          onClick={retryVoiceReview}
-                          icon={<Mic className="w-5 h-5" />}
-                        >
-                          重試語音
-                        </QuestButton>
-                      )}
-                    </div>
-                  )}
-                  {!speech.isSupported && (
-                    <p className="text-sm text-[color:var(--eq-muted)] text-center" role="alert">
-                      Speech recognition is not supported in this browser.
-                    </p>
-                  )}
-
-                  {practiceMode === 'spelling' && (
-                    <QuestButton
-                      variant="gold"
-                      onClick={() => handleSubmit(userInput)}
-                      icon={<Sword className="w-5 h-5" />}
-                    >
-                      攻擊!
-                    </QuestButton>
-                  )}
-
-                  <div className="flex gap-3 items-center">
-                    <IconButton
-                      aria-label="Show hint"
-                      onMouseDown={() => dispatch({ type: 'SET_SHOW_HINT', payload: true })}
-                      onMouseUp={() => dispatch({ type: 'SET_SHOW_HINT', payload: false })}
-                      onTouchStart={() => dispatch({ type: 'SET_SHOW_HINT', payload: true })}
-                      onTouchEnd={() => dispatch({ type: 'SET_SHOW_HINT', payload: false })}
-                    >
-                      <HelpCircle className="w-6 h-6" />
-                    </IconButton>
-                    <IconButton aria-label="Skip word" onClick={handleSkip} variant="danger">
-                      <SkipForward className="w-6 h-6" />
-                    </IconButton>
-                  </div>
-                </div>
-
-                {message && (
-                  <div className="text-center">
-                    <p className="eq-message animate-bounce">
-                      {message}
-                    </p>
-                  </div>
-                )}
-              </Panel>
-            )}
-          </div>
-        </div>
-      </ScreenShell>
-    );
+  const handleTogglePracticeMode = () => {
+    if (practiceMode === 'voice' || speech.isSupported) {
+      if (practiceMode === 'spelling') {
+        speech.clearError();
+      }
+      if (practiceMode === 'voice' && speech.error) {
+        speech.clearError();
+      }
+      updateVoiceReview(null);
+      dispatch({ type: 'TOGGLE_PRACTICE_MODE' });
+    }
   };
 
-  const renderMenu = () => (
-    <ScreenShell screen="menu" label="EchoQuest 主選單">
-      <div className="eq-menu">
-        <section>
-          <div className="eq-menu__mark" aria-hidden="true">
-            <Sparkles className="w-12 h-12" />
-          </div>
-          <h1 className="eq-display eq-menu__title">EchoQuest</h1>
-          <p className="eq-menu__subtitle">學習英文，打敗怪物！</p>
-        </section>
-
-        <Panel className="p-6 sm:p-8">
-          <div className="mb-6 flex justify-center">
-            <LanguageSelector selectedLang={recognitionLang} onLangChange={(lang) => dispatch({ type: 'SET_RECOGNITION_LANG', payload: lang })} isMenu={true} />
-          </div>
-          <div className="eq-menu__actions">
-            <QuestButton onClick={startGame} className="w-full" icon={<Sword className="w-5 h-5" />}>
-              開始遊戲
-            </QuestButton>
-            <QuestButton
-              variant="quiet"
-              onClick={() => dispatch({ type: 'SET_GAME_STATE', payload: 'vocab_management' })}
-              className="w-full"
-              icon={<Settings className="w-5 h-5" />}
-            >
-              字彙管理
-            </QuestButton>
-          </div>
-          {!speech.isSupported && (
-            <p className="mt-4 text-center text-sm text-[color:var(--eq-muted)]" role="alert">
-              Speech recognition is not supported in this browser.
-            </p>
-          )}
-          {message && (
-            <p className="eq-message text-center animate-bounce">
-              {message}
-            </p>
-          )}
-        </Panel>
-      </div>
-    </ScreenShell>
-  );
-
-  const renderVictory = () => (
-    <ScreenShell screen="victory" label="EchoQuest 勝利結果" className="grid place-items-center">
-      <Panel className="w-full max-w-md p-8 text-center">
-        <Trophy className="w-20 h-20 text-[color:var(--eq-sun)] mx-auto mb-4" />
-        <h1 className="eq-display text-4xl font-extrabold text-[color:var(--eq-ink)] mb-4">勝利！</h1>
-        <p className="text-2xl font-extrabold text-[color:var(--eq-river)] mb-2">最終分數: {score}</p>
-        <p className="text-lg text-[color:var(--eq-muted)] mb-6">答對 {correctAnswers} 個單字</p>
-        <QuestButton onClick={startGame} className="w-full" variant="gold" icon={<Trophy className="w-5 h-5" />}>
-          再玩一次
-        </QuestButton>
-      </Panel>
-    </ScreenShell>
-  );
+  const handleToggleListening = () => {
+    if (speech.listening) {
+      speech.stop();
+    } else {
+      speech.start(recognitionLang);
+    }
+  };
 
   switch (gameState) {
     case 'menu':
-      return renderMenu();
+      return (
+        <MenuScreen
+          recognitionLang={recognitionLang}
+          speechSupported={speech.isSupported}
+          message={message}
+          onRecognitionLangChange={(lang) => dispatch({ type: 'SET_RECOGNITION_LANG', payload: lang })}
+          onStartGame={startGame}
+          onOpenVocabManagement={() => dispatch({ type: 'SET_GAME_STATE', payload: 'vocab_management' })}
+        />
+      );
     case 'playing':
-      return renderGame();
+      return (
+        <GameScreen
+          level={levels[currentLevel]}
+          currentLevel={currentLevel}
+          currentWord={currentWord}
+          userInput={userInput}
+          score={score}
+          enemyLives={enemyLives}
+          collectedTools={collectedTools}
+          message={message}
+          practiceMode={practiceMode}
+          levelCorrectAnswers={levelCorrectAnswers}
+          skippedWords={skippedWords}
+          showEffect={showEffect}
+          combo={combo}
+          showHint={showHint}
+          isBossShaking={isBossShaking}
+          recognitionLang={recognitionLang}
+          speech={speech}
+          speechErrorMessage={speech.error ? getSpeechErrorMessage(speech.error) : null}
+          canRetrySpeechError={practiceMode === 'voice' && speech.error !== null && !isBlockingSpeechError(speech.error)}
+          voiceReview={voiceReview}
+          onSubmit={handleSubmit}
+          onUserInputChange={(value) => dispatch({ type: 'SET_USER_INPUT', payload: value })}
+          onTogglePracticeMode={handleTogglePracticeMode}
+          onToggleListening={handleToggleListening}
+          onRecognitionLangChange={(lang) => dispatch({ type: 'SET_RECOGNITION_LANG', payload: lang })}
+          onShowHintChange={(show) => dispatch({ type: 'SET_SHOW_HINT', payload: show })}
+          onSkip={handleSkip}
+          onRetryVoiceReview={retryVoiceReview}
+          onConfirmVoiceReview={confirmVoiceReview}
+        />
+      );
     case 'victory':
-      return renderVictory();
+      return (
+        <VictoryScreen
+          score={score}
+          correctAnswers={correctAnswers}
+          onStartGame={startGame}
+        />
+      );
     case 'vocab_management':
         return <VocabManager vocab={vocab} onVocabChange={(v) => dispatch({ type: 'SET_VOCAB', payload: v })} onGoBack={() => dispatch({ type: 'SET_GAME_STATE', payload: 'menu' })} />;
     default:
-      return renderMenu();
+      return (
+        <MenuScreen
+          recognitionLang={recognitionLang}
+          speechSupported={speech.isSupported}
+          message={message}
+          onRecognitionLangChange={(lang) => dispatch({ type: 'SET_RECOGNITION_LANG', payload: lang })}
+          onStartGame={startGame}
+          onOpenVocabManagement={() => dispatch({ type: 'SET_GAME_STATE', payload: 'vocab_management' })}
+        />
+      );
   }
-};
-
-const LanguageSelector: React.FC<{selectedLang: string, onLangChange: (lang: string) => void, isMenu?: boolean}> = ({ selectedLang, onLangChange, isMenu = false }) => {
-    const languages = [
-        { code: 'en-US', name: 'English (US)' },
-        { code: 'en-GB', name: 'English (UK)' },
-        { code: 'zh-TW', name: '中文 (繁體)' },
-        { code: 'zh-CN', name: '中文 (简体)' },
-    ];
-
-    if (isMenu) {
-        return (
-            <div className="flex items-center gap-2">
-                <Globe className="w-6 h-6 text-[color:var(--eq-river)]" />
-                <select
-                    value={selectedLang}
-                    onChange={(e) => onLangChange(e.target.value)}
-                    aria-label="Select recognition language"
-                    className="eq-select"
-                >
-                    {languages.map(lang => <option key={lang.code} value={lang.code}>{lang.name}</option>)}
-                </select>
-            </div>
-        );
-    }
-
-    return (
-        <select
-            value={selectedLang}
-            onChange={(e) => onLangChange(e.target.value)}
-            className="eq-select"
-            aria-label="Select recognition language"
-        >
-            {languages.map(lang => <option key={lang.code} value={lang.code}>{lang.name}</option>)}
-        </select>
-    );
 };
 
 export default App;

--- a/web/src/components/LanguageSelector.test.tsx
+++ b/web/src/components/LanguageSelector.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LanguageSelector } from './LanguageSelector';
+
+describe('<LanguageSelector />', () => {
+  it('renders the menu selector and reports language changes', () => {
+    const handleLangChange = jest.fn();
+
+    render(
+      <LanguageSelector
+        selectedLang="en-US"
+        onLangChange={handleLangChange}
+        isMenu
+      />
+    );
+
+    const selector = screen.getByRole('combobox', { name: /select recognition language/i });
+
+    expect(selector).toHaveValue('en-US');
+    expect(screen.getByText('English (US)')).toBeInTheDocument();
+    expect(screen.getByText('中文 (繁體)')).toBeInTheDocument();
+
+    fireEvent.change(selector, { target: { value: 'en-GB' } });
+
+    expect(handleLangChange).toHaveBeenCalledWith('en-GB');
+  });
+
+  it('renders the compact selector with the current language', () => {
+    render(<LanguageSelector selectedLang="zh-TW" onLangChange={jest.fn()} />);
+
+    expect(screen.getByRole('combobox', { name: /select recognition language/i })).toHaveValue('zh-TW');
+    expect(screen.getByText('English (UK)')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/LanguageSelector.tsx
+++ b/web/src/components/LanguageSelector.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Globe } from 'lucide-react';
+
+type LanguageSelectorProps = {
+  selectedLang: string;
+  onLangChange: (lang: string) => void;
+  isMenu?: boolean;
+};
+
+const languages = [
+  { code: 'en-US', name: 'English (US)' },
+  { code: 'en-GB', name: 'English (UK)' },
+  { code: 'zh-TW', name: '中文 (繁體)' },
+  { code: 'zh-CN', name: '中文 (简体)' },
+];
+
+export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
+  selectedLang,
+  onLangChange,
+  isMenu = false,
+}) => {
+  const selector = (
+    <select
+      value={selectedLang}
+      onChange={(e) => onLangChange(e.target.value)}
+      aria-label="Select recognition language"
+      className="eq-select"
+    >
+      {languages.map((lang) => (
+        <option key={lang.code} value={lang.code}>
+          {lang.name}
+        </option>
+      ))}
+    </select>
+  );
+
+  if (isMenu) {
+    return (
+      <div className="flex items-center gap-2">
+        <Globe className="w-6 h-6 text-[color:var(--eq-river)]" />
+        {selector}
+      </div>
+    );
+  }
+
+  return selector;
+};

--- a/web/src/persistence/vocabStorage.test.ts
+++ b/web/src/persistence/vocabStorage.test.ts
@@ -1,0 +1,69 @@
+import type { VocabItem } from '../types/vocab';
+import {
+  STORAGE_KEY_LANG,
+  STORAGE_KEY_VOCAB,
+  hydrateDefaultVocabArtwork,
+  loadLangFromStorage,
+  loadVocabFromStorage,
+  saveLangToStorage,
+  saveVocabToStorage,
+} from './vocabStorage';
+
+describe('vocabStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('hydrates stored default vocabulary with bundled artwork', () => {
+    const storedApple: VocabItem = {
+      id: 'd1-1',
+      word: 'apple',
+      difficulty: 1,
+      enabled: true,
+      imageName: 'apple',
+      size: 0,
+      type: '',
+    };
+
+    expect(hydrateDefaultVocabArtwork([storedApple])).toEqual([
+      expect.objectContaining({
+        id: 'd1-1',
+        word: 'apple',
+        imageSrc: 'assets/generated/word-apple.png',
+      }),
+    ]);
+  });
+
+  it('returns an empty vocabulary list when stored JSON is invalid', () => {
+    localStorage.setItem(STORAGE_KEY_VOCAB, '{not-json');
+
+    expect(loadVocabFromStorage()).toEqual([]);
+  });
+
+  it('saves and loads custom vocabulary items', () => {
+    const customItem: VocabItem = {
+      id: 'custom-1',
+      word: 'custom',
+      difficulty: 2,
+      enabled: true,
+      imageName: 'custom.png',
+      imageDataUrl: 'data:image/png;base64,custom',
+      size: 12,
+      type: 'image/png',
+    };
+
+    saveVocabToStorage([customItem]);
+
+    expect(localStorage.getItem(STORAGE_KEY_VOCAB)).toBe(JSON.stringify([customItem]));
+    expect(loadVocabFromStorage()).toEqual([customItem]);
+  });
+
+  it('loads the default language and saves selected language', () => {
+    expect(loadLangFromStorage()).toBe('en-US');
+
+    saveLangToStorage('en-GB');
+
+    expect(localStorage.getItem(STORAGE_KEY_LANG)).toBe('en-GB');
+    expect(loadLangFromStorage()).toBe('en-GB');
+  });
+});

--- a/web/src/persistence/vocabStorage.ts
+++ b/web/src/persistence/vocabStorage.ts
@@ -1,0 +1,43 @@
+import { initialVocab as defaultInitialVocab } from '../data/vocab';
+import type { VocabItem } from '../types/vocab';
+
+export const STORAGE_KEY_VOCAB = 'echoquest_vocab_v1';
+export const STORAGE_KEY_LANG = 'echoquest_lang_v1';
+
+const DEFAULT_VOCAB_BY_ID = new Map(defaultInitialVocab.map((item) => [item.id, item]));
+const DEFAULT_VOCAB_BY_WORD = new Map(defaultInitialVocab.map((item) => [item.word, item]));
+
+export function hydrateDefaultVocabArtwork(items: VocabItem[]): VocabItem[] {
+  return items.map((item) => {
+    if (item.imageSrc || item.imageDataUrl) {
+      return item;
+    }
+
+    const defaultById = DEFAULT_VOCAB_BY_ID.get(item.id);
+    const defaultItem = defaultById?.word === item.word ? defaultById : DEFAULT_VOCAB_BY_WORD.get(item.word);
+
+    return defaultItem?.imageSrc ? { ...item, imageSrc: defaultItem.imageSrc } : item;
+  });
+}
+
+export function loadVocabFromStorage(): VocabItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_VOCAB);
+    if (!raw) return [];
+    return hydrateDefaultVocabArtwork(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+export function saveVocabToStorage(items: VocabItem[]) {
+  localStorage.setItem(STORAGE_KEY_VOCAB, JSON.stringify(items));
+}
+
+export function loadLangFromStorage(): string {
+  return localStorage.getItem(STORAGE_KEY_LANG) || 'en-US';
+}
+
+export function saveLangToStorage(lang: string) {
+  localStorage.setItem(STORAGE_KEY_LANG, lang);
+}

--- a/web/src/screens/GameScreen.tsx
+++ b/web/src/screens/GameScreen.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+import { Heart, HelpCircle, Mic, MicOff, Skull, SkipForward, Star, Sword, Trophy, Volume2, Zap } from 'lucide-react';
+import { IconButton, Panel, QuestButton, ScreenShell, StatBadge } from '../components/QuestFrame';
+import { LanguageSelector } from '../components/LanguageSelector';
+import type { Level } from '../data/levels';
+import type { AppState } from '../game/gameReducer';
+import type { VocabItem } from '../types/vocab';
+
+type VoiceReviewResult = {
+  heardText: string;
+  targetWord: string;
+  isMatch: boolean;
+};
+
+type SpeechViewModel = {
+  listening: boolean;
+  transcript: string;
+  interimTranscript: string;
+  isSupported: boolean;
+  error: string | null;
+};
+
+type GameScreenProps = {
+  level: Level;
+  currentLevel: number;
+  currentWord: VocabItem | null;
+  userInput: string;
+  score: number;
+  enemyLives: number;
+  collectedTools: string[];
+  message: string;
+  practiceMode: AppState['practiceMode'];
+  levelCorrectAnswers: number;
+  skippedWords: number;
+  showEffect: boolean;
+  combo: number;
+  showHint: boolean;
+  isBossShaking: boolean;
+  recognitionLang: string;
+  speech: SpeechViewModel;
+  speechErrorMessage: string | null;
+  canRetrySpeechError: boolean;
+  voiceReview: VoiceReviewResult | null;
+  onSubmit: (submittedText: string) => void;
+  onUserInputChange: (value: string) => void;
+  onTogglePracticeMode: () => void;
+  onToggleListening: () => void;
+  onRecognitionLangChange: (lang: string) => void;
+  onShowHintChange: (show: boolean) => void;
+  onSkip: () => void;
+  onRetryVoiceReview: () => void;
+  onConfirmVoiceReview: () => void;
+};
+
+export function GameScreen({
+  level,
+  currentLevel,
+  currentWord,
+  userInput,
+  score,
+  enemyLives,
+  collectedTools,
+  message,
+  practiceMode,
+  levelCorrectAnswers,
+  skippedWords,
+  showEffect,
+  combo,
+  showHint,
+  isBossShaking,
+  recognitionLang,
+  speech,
+  speechErrorMessage,
+  canRetrySpeechError,
+  voiceReview,
+  onSubmit,
+  onUserInputChange,
+  onTogglePracticeMode,
+  onToggleListening,
+  onRecognitionLangChange,
+  onShowHintChange,
+  onSkip,
+  onRetryVoiceReview,
+  onConfirmVoiceReview,
+}: GameScreenProps) {
+  const speechUnavailable = !speech.isSupported;
+  const totalEnemyLives = level.enemyLives ?? enemyLives;
+  const objectiveText = level.type === 'puzzle'
+    ? `目標: 收集 ${collectedTools.length}/${level.tools?.length || level.requiredWords} 個工具`
+    : `目標: 答對 ${levelCorrectAnswers}/${level.requiredWords} 個單字，或清空生命值 ${enemyLives}/${totalEnemyLives}`;
+  const currentWordImageSrc = currentWord?.imageDataUrl ?? currentWord?.imageSrc;
+
+  return (
+    <ScreenShell screen="playing" label="EchoQuest 遊戲進行中">
+      <div className="eq-game-shell">
+        <div className="eq-hud" aria-label="冒險狀態">
+          <StatBadge icon={<Trophy className="w-6 h-6" />} label="得分" value={`分數: ${score}`} tone="gold" />
+          <StatBadge icon={<Zap className="w-6 h-6" />} label="節奏" value={`連擊 x${combo}`} tone="green" />
+          <StatBadge icon={<SkipForward className="w-6 h-6" />} label="選擇" value={`跳過 ${skippedWords} 次`} tone="blue" />
+          <StatBadge icon={<Star className="w-6 h-6" />} label="進度" value={`關卡 ${currentLevel + 1}`} tone="red" />
+        </div>
+
+        <div className="eq-game-grid">
+          <Panel className="eq-level-panel">
+            <p className="text-sm font-extrabold uppercase text-[color:var(--eq-muted)]">Quest Log</p>
+            <h2 className="eq-display eq-level-title">{level.name}</h2>
+            <p className="mt-2 text-[color:var(--eq-muted)]">{level.description}</p>
+            <p className="eq-objective">{objectiveText}</p>
+
+            <div className={`eq-enemy-figure ${isBossShaking ? 'shake' : ''}`}>
+              {level.imageSrc ? (
+                <img src={level.imageSrc} alt={`${level.name} artwork`} className="eq-enemy-artwork" />
+              ) : (
+                <span aria-hidden="true">{level.imageEmoji}</span>
+              )}
+            </div>
+
+            {level.type === 'boss' && (
+              <div className="flex justify-center items-center gap-2" aria-label="Boss health">
+                <Skull className="w-7 h-7 text-[color:var(--eq-rust)]" />
+                <div className="flex gap-1">
+                  {[...Array(level.enemyLives ?? 0)].map((_, i) => (
+                    <Heart
+                      key={i}
+                      className={`w-7 h-7 ${i < enemyLives ? 'text-[color:var(--eq-rust)]' : 'text-stone-300'}`}
+                      fill={i < enemyLives ? 'currentColor' : 'none'}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {level.type === 'puzzle' && (
+              <div className="flex justify-center items-center gap-2 text-4xl" aria-label="Puzzle progress">
+                {[...Array(level.tools ? level.tools.length - collectedTools.length : 0)].map((_, i) => (
+                  <span key={i}>🚪</span>
+                ))}
+                {[...Array(collectedTools.length)].map((_, i) => (
+                  <span key={i} className="opacity-50">🔑</span>
+                ))}
+              </div>
+            )}
+          </Panel>
+
+          {currentWord && (
+            <Panel className="eq-challenge-panel">
+              <div className={`eq-word-stage ${showEffect ? 'eq-word-stage--success' : ''}`}>
+                {currentWordImageSrc ? (
+                  <img src={currentWordImageSrc} alt={currentWord.word} className="eq-word-photo" />
+                ) : (
+                  <div className="eq-word-image" aria-hidden="true">{currentWord.imageName}</div>
+                )}
+                <div className="mt-4 flex justify-center gap-1">
+                  {[...Array(currentWord.difficulty)].map((_, i) => (
+                    <Star key={i} className="w-5 h-5 text-[color:var(--eq-sun)]" fill="currentColor" />
+                  ))}
+                </div>
+                <p className="mt-1 text-sm font-bold text-[color:var(--eq-muted)]">難度等級</p>
+                {showHint && (
+                  <div className="eq-hint-overlay">
+                    <span className="eq-display text-4xl font-extrabold">{currentWord.word}</span>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col items-center gap-4">
+                <div className="eq-transcript w-full">
+                  <p className="text-xl">
+                    <span className="font-extrabold text-[color:var(--eq-river)]">{speech.transcript}</span>
+                    <span className="text-[color:var(--eq-muted)]">{speech.interimTranscript}</span>
+                  </p>
+                </div>
+
+                {voiceReview && practiceMode === 'voice' && (
+                  <div className="eq-voice-review w-full" role="status" aria-live="polite">
+                    <p className="text-lg font-extrabold text-[color:var(--eq-river)]">聽到：{voiceReview.heardText}</p>
+                    <p className="text-sm font-bold text-[color:var(--eq-muted)]">目標：{voiceReview.targetWord}</p>
+                    <p className="text-sm text-[color:var(--eq-muted)]">
+                      {voiceReview.isMatch ? '聽起來很接近，確認後發動攻擊。' : '還沒聽準，可以重試一次。'}
+                    </p>
+                    <div className="eq-voice-review__actions">
+                      <QuestButton
+                        variant="secondary"
+                        onClick={onRetryVoiceReview}
+                        icon={<Mic className="w-5 h-5" />}
+                      >
+                        重試語音
+                      </QuestButton>
+                      <QuestButton
+                        variant="gold"
+                        onClick={onConfirmVoiceReview}
+                        icon={<Sword className="w-5 h-5" />}
+                      >
+                        確認送出
+                      </QuestButton>
+                    </div>
+                  </div>
+                )}
+
+                <div className="eq-control-row">
+                  <QuestButton
+                    variant={practiceMode === 'voice' ? 'secondary' : 'quiet'}
+                    onClick={onTogglePracticeMode}
+                    aria-label={practiceMode === 'voice' ? '切換到拼字模式' : '切換到語音模式'}
+                    disabled={practiceMode === 'spelling' && speechUnavailable}
+                    icon={practiceMode === 'voice' ? <Mic className="w-5 h-5" /> : <MicOff className="w-5 h-5" />}
+                  >
+                    {practiceMode === 'voice' ? '語音' : '拼字'}
+                  </QuestButton>
+
+                  {practiceMode === 'voice' ? (
+                    <QuestButton
+                      variant={speech.listening ? 'danger' : 'primary'}
+                      onClick={onToggleListening}
+                      disabled={speechUnavailable}
+                      icon={<Volume2 className="w-5 h-5" />}
+                    >
+                      {speech.listening ? '聆聽中...' : '點擊說話'}
+                    </QuestButton>
+                  ) : (
+                    <input
+                      type="text"
+                      value={userInput}
+                      onChange={(e) => onUserInputChange(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && onSubmit(userInput)}
+                      placeholder="輸入英文單字"
+                      className="eq-input"
+                    />
+                  )}
+                  <LanguageSelector selectedLang={recognitionLang} onLangChange={onRecognitionLangChange} />
+                </div>
+
+                {speech.error && speechErrorMessage && (
+                  <div className="flex flex-col items-center gap-3" role="alert">
+                    <p className="text-sm text-[color:var(--eq-ruby)] text-center">
+                      {speechErrorMessage}
+                    </p>
+                    {canRetrySpeechError && (
+                      <QuestButton
+                        variant="secondary"
+                        onClick={onRetryVoiceReview}
+                        icon={<Mic className="w-5 h-5" />}
+                      >
+                        重試語音
+                      </QuestButton>
+                    )}
+                  </div>
+                )}
+                {!speech.isSupported && (
+                  <p className="text-sm text-[color:var(--eq-muted)] text-center" role="alert">
+                    Speech recognition is not supported in this browser.
+                  </p>
+                )}
+
+                {practiceMode === 'spelling' && (
+                  <QuestButton
+                    variant="gold"
+                    onClick={() => onSubmit(userInput)}
+                    icon={<Sword className="w-5 h-5" />}
+                  >
+                    攻擊!
+                  </QuestButton>
+                )}
+
+                <div className="flex gap-3 items-center">
+                  <IconButton
+                    aria-label="Show hint"
+                    onMouseDown={() => onShowHintChange(true)}
+                    onMouseUp={() => onShowHintChange(false)}
+                    onTouchStart={() => onShowHintChange(true)}
+                    onTouchEnd={() => onShowHintChange(false)}
+                  >
+                    <HelpCircle className="w-6 h-6" />
+                  </IconButton>
+                  <IconButton aria-label="Skip word" onClick={onSkip} variant="danger">
+                    <SkipForward className="w-6 h-6" />
+                  </IconButton>
+                </div>
+              </div>
+
+              {message && (
+                <div className="text-center">
+                  <p className="eq-message animate-bounce">
+                    {message}
+                  </p>
+                </div>
+              )}
+            </Panel>
+          )}
+        </div>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/web/src/screens/MenuScreen.tsx
+++ b/web/src/screens/MenuScreen.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Settings, Sparkles, Sword } from 'lucide-react';
+import { LanguageSelector } from '../components/LanguageSelector';
+import { Panel, QuestButton, ScreenShell } from '../components/QuestFrame';
+
+type MenuScreenProps = {
+  recognitionLang: string;
+  speechSupported: boolean;
+  message: string;
+  onRecognitionLangChange: (lang: string) => void;
+  onStartGame: () => void;
+  onOpenVocabManagement: () => void;
+};
+
+export function MenuScreen({
+  recognitionLang,
+  speechSupported,
+  message,
+  onRecognitionLangChange,
+  onStartGame,
+  onOpenVocabManagement,
+}: MenuScreenProps) {
+  return (
+    <ScreenShell screen="menu" label="EchoQuest 主選單">
+      <div className="eq-menu">
+        <section>
+          <div className="eq-menu__mark" aria-hidden="true">
+            <Sparkles className="w-12 h-12" />
+          </div>
+          <h1 className="eq-display eq-menu__title">EchoQuest</h1>
+          <p className="eq-menu__subtitle">學習英文，打敗怪物！</p>
+        </section>
+
+        <Panel className="p-6 sm:p-8">
+          <div className="mb-6 flex justify-center">
+            <LanguageSelector selectedLang={recognitionLang} onLangChange={onRecognitionLangChange} isMenu />
+          </div>
+          <div className="eq-menu__actions">
+            <QuestButton onClick={onStartGame} className="w-full" icon={<Sword className="w-5 h-5" />}>
+              開始遊戲
+            </QuestButton>
+            <QuestButton
+              variant="quiet"
+              onClick={onOpenVocabManagement}
+              className="w-full"
+              icon={<Settings className="w-5 h-5" />}
+            >
+              字彙管理
+            </QuestButton>
+          </div>
+          {!speechSupported && (
+            <p className="mt-4 text-center text-sm text-[color:var(--eq-muted)]" role="alert">
+              Speech recognition is not supported in this browser.
+            </p>
+          )}
+          {message && (
+            <p className="eq-message text-center animate-bounce">
+              {message}
+            </p>
+          )}
+        </Panel>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/web/src/screens/VictoryScreen.tsx
+++ b/web/src/screens/VictoryScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Trophy } from 'lucide-react';
+import { Panel, QuestButton, ScreenShell } from '../components/QuestFrame';
+
+type VictoryScreenProps = {
+  score: number;
+  correctAnswers: number;
+  onStartGame: () => void;
+};
+
+export function VictoryScreen({ score, correctAnswers, onStartGame }: VictoryScreenProps) {
+  return (
+    <ScreenShell screen="victory" label="EchoQuest 勝利結果" className="grid place-items-center">
+      <Panel className="w-full max-w-md p-8 text-center">
+        <Trophy className="w-20 h-20 text-[color:var(--eq-sun)] mx-auto mb-4" />
+        <h1 className="eq-display text-4xl font-extrabold text-[color:var(--eq-ink)] mb-4">勝利！</h1>
+        <p className="text-2xl font-extrabold text-[color:var(--eq-river)] mb-2">最終分數: {score}</p>
+        <p className="text-lg text-[color:var(--eq-muted)] mb-6">答對 {correctAnswers} 個單字</p>
+        <QuestButton onClick={onStartGame} className="w-full" variant="gold" icon={<Trophy className="w-5 h-5" />}>
+          再玩一次
+        </QuestButton>
+      </Panel>
+    </ScreenShell>
+  );
+}


### PR DESCRIPTION
## Summary

- Split App rendering into `GameScreen`, `MenuScreen`, and `VictoryScreen` while keeping App as the reducer/effect coordinator.
- Extracted language selection and vocabulary/localStorage helpers into focused modules.
- Added focused tests for storage hydration/persistence and language selector behavior.

## Verification

- `npm test -- --runInBand` (74 passed)
- `npm run build`
- `git diff --cached --check`

Closes #55.