### PR TITLE
Add learning progress model

### DIFF
--- a/docs/superpowers/plans/2026-06-01-learning-progress-model.md
+++ b/docs/superpowers/plans/2026-06-01-learning-progress-model.md
@@ -1,0 +1,270 @@
+# Learning Progress Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent per-word learning progress, weak-word selection priority, actionable answer feedback, and a lightweight victory learning summary.
+
+**Architecture:** Learning math lives in `web/src/learning/progress.ts`, persistence lives in `web/src/persistence/progressStorage.ts`, and `App.tsx` coordinates updates with the existing reducer and screens. Vocabulary storage remains unchanged; progress uses a separate localStorage key.
+
+**Tech Stack:** React 18, TypeScript, Jest, Testing Library, localStorage.
+
+---
+
+## File Structure
+
+- Create: `web/src/learning/progress.ts`
+  - Owns progress types, attempt recording, review ranking, and summary helpers.
+- Create: `web/src/learning/progress.test.ts`
+  - TDD coverage for mastery updates, due timing, ranking, and summary.
+- Create: `web/src/persistence/progressStorage.ts`
+  - Owns `echoquest_progress_v1` load/save.
+- Create: `web/src/persistence/progressStorage.test.ts`
+  - Covers invalid JSON fallback, shape filtering, and round trip.
+- Modify: `web/src/game/gameReducer.ts`
+  - Adds progress and answer feedback to state/actions.
+- Modify: `web/src/game/gameReducer.test.ts`
+  - Covers progress state setting and feedback clearing on new game/word.
+- Modify: `web/src/App.tsx`
+  - Loads/persists progress, records attempts, ranks available words, passes feedback/summary to screens.
+- Modify: `web/src/screens/GameScreen.tsx`
+  - Renders actionable answer feedback.
+- Modify: `web/src/screens/VictoryScreen.tsx`
+  - Renders learning summary.
+- Modify: `web/src/App.test.tsx`
+  - Covers persisted progress, weak-word priority, incorrect feedback, and victory summary.
+
+## Task 1: Baseline Verification
+
+- [ ] **Step 1: Confirm branch and clean start**
+
+Run: `git status --short --branch`
+
+Expected: current branch is `codex/learning-progress-model`; no uncommitted source changes except this plan before commit.
+
+- [ ] **Step 2: Run current tests**
+
+Run from `web`: `npm test -- --runInBand`
+
+Expected: all current tests pass before implementation begins.
+
+## Task 2: Learning Progress Model TDD
+
+**Files:**
+- Create: `web/src/learning/progress.test.ts`
+- Create: `web/src/learning/progress.ts`
+
+- [ ] **Step 1: Write failing tests for progress updates**
+
+Create tests importing:
+
+```ts
+import {
+  buildLearningSummary,
+  createAnswerFeedback,
+  rankWordsForReview,
+  recordPracticeAttempt,
+} from './progress';
+```
+
+Test these concrete behaviors:
+
+- A first correct spelling attempt creates progress with `attempts: 1`, `correct: 1`, `misses: 0`, `streak: 1`, `mastery: 1`, `lastMode: 'spelling'`, and `dueAt` later than `now`.
+- An incorrect voice attempt resets `streak` to `0`, increments `misses`, keeps `mastery: 0`, sets `lastMissedAt`, and makes `dueAt === now`.
+- Three consecutive correct attempts cap mastery at `3`.
+- `rankWordsForReview` puts due lower-mastery words ahead of stable words.
+- `buildLearningSummary` counts practiced, mastered, and due words.
+- `createAnswerFeedback` includes submitted text, target word, correctness, mode, mastery, and a readable next review label.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/learning/progress.test.ts --runInBand`
+
+Expected: FAIL because `./progress` does not exist.
+
+- [ ] **Step 3: Implement minimal learning model**
+
+Create `web/src/learning/progress.ts` with exported types:
+
+```ts
+export type PracticeMode = 'voice' | 'spelling';
+export type MasteryLevel = 0 | 1 | 2 | 3;
+export type LearningProgressState = Record<string, WordProgress>;
+```
+
+Implement:
+
+- `recordPracticeAttempt(progress, word, attempt)` returning a new progress object.
+- `rankWordsForReview(words, progress, now)` returning a sorted copy.
+- `buildLearningSummary(progress, now)` returning `{ practicedWords, masteredWords, dueWords }`.
+- `createAnswerFeedback({ word, submitted, isCorrect, mode, progress, now })`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run from `web`: `npm test -- src/learning/progress.test.ts --runInBand`
+
+Expected: PASS.
+
+## Task 3: Progress Storage TDD
+
+**Files:**
+- Create: `web/src/persistence/progressStorage.test.ts`
+- Create: `web/src/persistence/progressStorage.ts`
+
+- [ ] **Step 1: Write failing storage tests**
+
+Test imports:
+
+```ts
+import {
+  STORAGE_KEY_PROGRESS,
+  loadProgressFromStorage,
+  saveProgressToStorage,
+} from './progressStorage';
+```
+
+Test:
+
+- Missing storage returns `{}`.
+- Invalid JSON returns `{}`.
+- A valid progress object round-trips through `echoquest_progress_v1`.
+- Existing `echoquest_vocab_v1` remains untouched when saving progress.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/persistence/progressStorage.test.ts --runInBand`
+
+Expected: FAIL because `./progressStorage` does not exist.
+
+- [ ] **Step 3: Implement storage module**
+
+Create `progressStorage.ts` with:
+
+```ts
+export const STORAGE_KEY_PROGRESS = 'echoquest_progress_v1';
+```
+
+Use `JSON.parse` inside `try/catch`; accept only object values.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run from `web`: `npm test -- src/persistence/progressStorage.test.ts --runInBand`
+
+Expected: PASS.
+
+## Task 4: Reducer State and Feedback TDD
+
+**Files:**
+- Modify: `web/src/game/gameReducer.test.ts`
+- Modify: `web/src/game/gameReducer.ts`
+
+- [ ] **Step 1: Write failing reducer tests**
+
+Add tests that assert:
+
+- `createInitialState()` includes `progress: {}` and `lastAnswerFeedback: null`.
+- `SET_PROGRESS` replaces progress.
+- `SET_LAST_ANSWER_FEEDBACK` stores feedback.
+- `START_GAME` clears `lastAnswerFeedback` but preserves persisted `progress`.
+- `SELECT_NEW_WORD` clears `lastAnswerFeedback` with user input.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/game/gameReducer.test.ts --runInBand`
+
+Expected: FAIL because action/state fields do not exist.
+
+- [ ] **Step 3: Implement reducer fields/actions**
+
+Add imports for learning types, extend `AppState`, add actions:
+
+```ts
+| { type: 'SET_PROGRESS'; payload: LearningProgressState }
+| { type: 'SET_LAST_ANSWER_FEEDBACK'; payload: AnswerFeedback | null }
+```
+
+Keep scoring actions unchanged.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run from `web`: `npm test -- src/game/gameReducer.test.ts --runInBand`
+
+Expected: PASS.
+
+## Task 5: App Integration TDD
+
+**Files:**
+- Modify: `web/src/App.test.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/screens/GameScreen.tsx`
+- Modify: `web/src/screens/VictoryScreen.tsx`
+
+- [ ] **Step 1: Write failing App tests**
+
+Add tests that assert:
+
+- Incorrect spelling answer shows `你輸入「wronganswer」，目標是 apple` and persists a miss for the current word in `echoquest_progress_v1`.
+- Correct answer persists a correct attempt for the current word.
+- When stored progress marks one available word as due/weak, starting the game selects that word before stable alternatives.
+- Victory screen includes `練習單字`, `精熟單字`, and `待複習`.
+
+- [ ] **Step 2: Verify RED**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: FAIL because App does not load/persist progress or render learning feedback.
+
+- [ ] **Step 3: Wire progress into App**
+
+In `App.tsx`:
+
+- Load progress from `loadProgressFromStorage()` into reducer on mount.
+- Persist `progress` through `saveProgressToStorage(progress)`.
+- In `handleSubmit`, call `recordPracticeAttempt` with current word, submitted text, correctness, mode, and `Date.now()`.
+- Dispatch `SET_PROGRESS` and `SET_LAST_ANSWER_FEEDBACK`.
+- Rank `availableWords` with `rankWordsForReview` before calling `selectWord`.
+- Pass `lastAnswerFeedback` to `GameScreen`.
+- Pass `buildLearningSummary(progress, Date.now())` to `VictoryScreen`.
+
+- [ ] **Step 4: Render feedback and summary**
+
+In `GameScreen`, render a concise feedback block when `lastAnswerFeedback` is present.
+
+In `VictoryScreen`, render learning summary rows:
+
+- `練習單字: N`
+- `精熟單字: N`
+- `待複習: N`
+
+- [ ] **Step 5: Verify GREEN**
+
+Run from `web`: `npm test -- src/App.test.tsx --runInBand`
+
+Expected: PASS.
+
+## Task 6: Final Verification and PR
+
+- [ ] **Step 1: Run full tests**
+
+Run from `web`: `npm test -- --runInBand`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run production build**
+
+Run from `web`: `npm run build`
+
+Expected: TypeScript and esbuild complete successfully.
+
+- [ ] **Step 3: Inspect diff**
+
+Run: `git diff --stat` and `git diff --check`
+
+Expected: focused #59 changes and no whitespace errors.
+
+- [ ] **Step 4: Commit implementation**
+
+Commit message: `feat: add learning progress model`
+
+- [ ] **Step 5: Push and open PR**
+
+Push `codex/learning-progress-model` and open a PR to `main` with `Closes #59`.

--- a/docs/superpowers/specs/2026-06-01-learning-progress-model-design.md
+++ b/docs/superpowers/specs/2026-06-01-learning-progress-model-design.md
@@ -1,0 +1,147 @@
+# Learning Progress Model Design
+
+## Context
+
+Issue #59 asks EchoQuest to remember what the learner knows, which words they miss, and which words should come back for review. The current game tracks only session score, combo, correct answer count, and skipped words. Vocabulary definitions already persist through `echoquest_vocab_v1`; learning progress must be stored separately so imported vocabulary is not corrupted.
+
+## Goals
+
+- Persist per-word learning progress independently from vocabulary definitions.
+- Record every submitted answer with mode, correctness, timestamp, streak, and miss/correct totals.
+- Prioritize weak or due-for-review words during word selection while preserving level constraints and puzzle tool rules.
+- Show actionable mistake feedback that includes the target word and the submitted answer.
+- Add a lightweight victory summary with learning progress, not only score.
+- Keep the first implementation small enough to review and merge safely.
+
+## Non-Goals
+
+- No large dashboard, mastery charts, account sync, analytics backend, or full spaced-repetition scheduler.
+- No pronunciation scoring beyond recording voice vs spelling attempts.
+- No visual redesign; UI additions should use existing components and class patterns.
+- No change to the existing vocabulary storage key or stored vocabulary shape.
+
+## Data Model
+
+Create `web/src/learning/progress.ts` with:
+
+```ts
+export type PracticeMode = 'voice' | 'spelling';
+
+export type WordProgress = {
+  wordId: string;
+  word: string;
+  attempts: number;
+  correct: number;
+  misses: number;
+  streak: number;
+  mastery: 0 | 1 | 2 | 3;
+  lastPracticedAt: number | null;
+  lastMissedAt: number | null;
+  lastMode: PracticeMode | null;
+  dueAt: number;
+};
+
+export type LearningProgressState = Record<string, WordProgress>;
+```
+
+The key is the vocabulary item id, not the word string. The word string is stored as a display snapshot in case the item is renamed later.
+
+Mastery is intentionally simple:
+
+- `0`: new or struggling.
+- `1`: one recent correct answer.
+- `2`: two or more correct streak.
+- `3`: three or more correct streak.
+
+Review timing is lightweight:
+
+- Incorrect answers are due immediately.
+- Mastery 0 correct answers are due in 1 hour.
+- Mastery 1 correct answers are due in 1 day.
+- Mastery 2 correct answers are due in 3 days.
+- Mastery 3 correct answers are due in 7 days.
+
+## Storage
+
+Create `web/src/persistence/progressStorage.ts` using key `echoquest_progress_v1`.
+
+Exports:
+
+- `loadProgressFromStorage(): LearningProgressState`
+- `saveProgressToStorage(progress: LearningProgressState): void`
+
+Invalid JSON or unexpected shapes return an empty object. This keeps bad progress data from breaking gameplay.
+
+## Game Integration
+
+`AppState` gains:
+
+- `progress: LearningProgressState`
+- `lastAnswerFeedback: AnswerFeedback | null`
+
+Answer feedback contains:
+
+```ts
+type AnswerFeedback = {
+  word: string;
+  submitted: string;
+  isCorrect: boolean;
+  mode: PracticeMode;
+  mastery: WordProgress['mastery'];
+  nextReviewLabel: string;
+};
+```
+
+`handleSubmit` computes correctness, updates progress with `recordPracticeAttempt`, dispatches the existing scoring action, and persists progress through a React effect.
+
+Incorrect answer copy changes from a generic message to a learner-facing line such as:
+
+`再試一次：你輸入「apl」，目標是 apple。這題會優先複習。`
+
+Voice submissions use the same feedback shape, with `mode: 'voice'`.
+
+## Word Selection
+
+Add `rankWordsForReview(words, progress, now)` in `web/src/learning/progress.ts`. It does not replace level filtering. `App.tsx` still calls `getAvailableWords` first, then ranks those candidates before `selectWord`.
+
+Ranking:
+
+1. Due words first.
+2. Lower mastery first.
+3. Higher misses first.
+4. Never-practiced words before already-stable words.
+5. Preserve the existing random selection among the best priority group.
+
+This keeps the game feeling varied while nudging practice toward weak words.
+
+## UI
+
+`GameScreen` receives `lastAnswerFeedback` and renders a small feedback block inside the challenge panel when available. It appears with the existing message area and uses existing color tokens.
+
+`VictoryScreen` receives a summary:
+
+- words practiced this run
+- mastered words
+- review words due now
+
+The first version only needs text; future #60 can animate it.
+
+## Testing Strategy
+
+- Unit-test progress math in `web/src/learning/progress.test.ts`.
+- Unit-test storage fallback and round-trip in `web/src/persistence/progressStorage.test.ts`.
+- Extend reducer tests for progress and feedback state updates.
+- Extend App tests for:
+  - incorrect feedback includes submitted and target word,
+  - progress persists after a correct/incorrect answer,
+  - weak/due words are prioritized when selecting the next word,
+  - victory screen shows learning summary.
+
+## Acceptance Criteria
+
+- Progress persists in `echoquest_progress_v1` and never overwrites `echoquest_vocab_v1`.
+- Correct and incorrect submissions update per-word progress.
+- Word selection prioritizes due/weak words within existing available-word constraints.
+- Incorrect answers provide actionable feedback beyond `再試一次!`.
+- Victory screen shows a learning summary in addition to score.
+- Full test suite and production build pass.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -100,7 +100,7 @@ describe('<App />', () => {
     });
 
     afterEach(() => {
-        jest.spyOn(global.Math, 'random').mockRestore();
+        jest.restoreAllMocks();
         uninstallSpeechRecognitionMock();
     });
 
@@ -290,7 +290,107 @@ describe('<App />', () => {
     await waitFor(() => {
       expect(screen.getByText('再試一次! 連擊歸零，但不扣分。')).toBeInTheDocument();
     });
+    expect(screen.getByText('你輸入「wronganswer」，目標是 apple')).toBeInTheDocument();
     expect(screen.getByText('分數: 0')).toBeInTheDocument();
+  });
+
+  it('persists a miss after an incorrect spelling answer', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到拼字模式/i }));
+    fireEvent.change(screen.getByPlaceholderText('輸入英文單字'), { target: { value: 'wronganswer' } });
+    fireEvent.click(screen.getByText('攻擊!'));
+
+    await waitFor(() => {
+      const storedProgress = JSON.parse(localStorageMock.getItem('echoquest_progress_v1') || '{}');
+      expect(storedProgress['1']).toMatchObject({
+        wordId: '1',
+        word: 'apple',
+        attempts: 1,
+        correct: 0,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastMode: 'spelling',
+        dueAt: 1_700_000_000_000,
+      });
+    });
+    expect(localStorageMock.getItem('echoquest_vocab_v1')).toBeNull();
+    nowSpy.mockRestore();
+  });
+
+  it('persists a correct spelling answer', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+    await waitFor(() => {
+      expect(screen.getByText('關卡 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /切換到拼字模式/i }));
+    fireEvent.change(screen.getByPlaceholderText('輸入英文單字'), { target: { value: 'apple' } });
+    fireEvent.click(screen.getByText('攻擊!'));
+
+    await waitFor(() => {
+      const storedProgress = JSON.parse(localStorageMock.getItem('echoquest_progress_v1') || '{}');
+      expect(storedProgress['1']).toMatchObject({
+        wordId: '1',
+        word: 'apple',
+        attempts: 1,
+        correct: 1,
+        misses: 0,
+        streak: 1,
+        mastery: 1,
+        lastMode: 'spelling',
+      });
+    });
+    nowSpy.mockRestore();
+  });
+
+  it('prioritizes a due weak word when selecting the next challenge', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    localStorageMock.setItem('echoquest_progress_v1', JSON.stringify({
+      '1': {
+        wordId: '1',
+        word: 'apple',
+        attempts: 4,
+        correct: 4,
+        misses: 0,
+        streak: 4,
+        mastery: 3,
+        lastPracticedAt: 1_699_999_999_000,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: 1_700_086_400_000,
+      },
+      '2': {
+        wordId: '2',
+        word: 'sword',
+        attempts: 1,
+        correct: 0,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: 1_699_999_999_000,
+        lastMissedAt: 1_699_999_999_000,
+        lastMode: 'voice',
+        dueAt: 1_700_000_000_000,
+      },
+    }));
+
+    render(<App initialVocab={defaultTestVocab} />);
+    fireEvent.click(screen.getByText('開始遊戲'));
+
+    await waitFor(() => {
+      expect(screen.getByText('⚔️')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('🍎')).not.toBeInTheDocument();
+    nowSpy.mockRestore();
   });
 
   it('should skip to the next word when "Skip word" is clicked', async () => {
@@ -344,6 +444,7 @@ describe('<App />', () => {
   });
 
   it('should show the victory screen after defeating the final boss', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
     const victoryLevels: Level[] = [{ id: 1, name: 'Test Boss', type: 'boss', enemyLives: 1, description: '', imageEmoji: 'T', requiredWords: 1 }];
     const victoryVocab: VocabItem[] = [{ id: '1', word: 'apple', difficulty: 1, enabled: true, imageName: '🍎', size: 1, type: 'image/png' }];
 
@@ -367,6 +468,10 @@ describe('<App />', () => {
       expect(screen.getByText('勝利！')).toBeInTheDocument();
     }, { timeout: 2000 });
     expect(screen.getByRole('main', { name: 'EchoQuest 勝利結果' })).toHaveAttribute('data-screen', 'victory');
+    expect(screen.getByText('練習單字: 1')).toBeInTheDocument();
+    expect(screen.getByText('精熟單字: 0')).toBeInTheDocument();
+    expect(screen.getByText('待複習: 0')).toBeInTheDocument();
+    nowSpy.mockRestore();
   });
 
   it('should handle puzzle levels correctly', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,13 @@ import { useSpeechRecognition } from './hooks/useSpeechRecognition';
 import { defaultLevels, type Level } from './data/levels';
 import { calculateBossReward, getAvailableWords, isAnswerCorrect, isLevelComplete, selectWord } from './game/gameLogic';
 import { createInitialState, gameReducer } from './game/gameReducer';
+import {
+  buildLearningSummary,
+  createAnswerFeedback,
+  getTopReviewCandidates,
+  recordPracticeAttempt,
+} from './learning/progress';
+import { loadProgressFromStorage, saveProgressToStorage } from './persistence/progressStorage';
 import { loadLangFromStorage, loadVocabFromStorage, saveLangToStorage, saveVocabToStorage } from './persistence/vocabStorage';
 import { GameScreen } from './screens/GameScreen';
 import { MenuScreen } from './screens/MenuScreen';
@@ -51,6 +58,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   const [state, dispatch] = useReducer(gameReducer, createInitialState({
     levels: initialLevels,
     recognitionLang: loadLangFromStorage(),
+    progress: loadProgressFromStorage(),
   }));
   const [voiceReview, setVoiceReview] = useState<VoiceReviewResult | null>(null);
   const voiceReviewRef = useRef<VoiceReviewResult | null>(null);
@@ -79,6 +87,8 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     showHint,
     isBossShaking,
     recognitionLang,
+    progress,
+    lastAnswerFeedback,
   } = state;
 
   const acceptSpeechResultsRef = useRef(false);
@@ -127,6 +137,10 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     }
   }, [vocab, initialVocabProp]);
 
+  useEffect(() => {
+    saveProgressToStorage(progress);
+  }, [progress]);
+
   const enabledVocab = useMemo(() => vocab.filter((v: VocabItem) => v.enabled), [vocab]);
 
   const selectNewWord = () => {
@@ -139,7 +153,8 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
     const availableWords = getAvailableWords(vocab, level, collectedTools);
     
     if (availableWords.length > 0) {
-      const randomWord = selectWord(availableWords, Math.random, currentWord?.id);
+      const reviewCandidates = getTopReviewCandidates(availableWords, progress, Date.now());
+      const randomWord = selectWord(reviewCandidates, Math.random, currentWord?.id);
       dispatch({ type: 'SELECT_NEW_WORD', payload: randomWord });
     } else {
         // No more words for this level
@@ -215,7 +230,27 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
   const handleSubmit = (submittedText: string) => {
     if (!currentWord) return;
     
+    const now = Date.now();
     const isCorrect = isAnswerCorrect(submittedText, currentWord);
+    const nextProgress = recordPracticeAttempt(progress, currentWord, {
+      isCorrect,
+      mode: practiceMode,
+      now,
+    });
+    const wordProgress = nextProgress[currentWord.id];
+
+    dispatch({ type: 'SET_PROGRESS', payload: nextProgress });
+    dispatch({
+      type: 'SET_LAST_ANSWER_FEEDBACK',
+      payload: createAnswerFeedback({
+        word: currentWord,
+        submitted: submittedText,
+        isCorrect,
+        mode: practiceMode,
+        progress: wordProgress,
+        now,
+      }),
+    });
     
     if (isCorrect) {
       const level = levels[currentLevel];
@@ -375,6 +410,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
           speechErrorMessage={speech.error ? getSpeechErrorMessage(speech.error) : null}
           canRetrySpeechError={practiceMode === 'voice' && speech.error !== null && !isBlockingSpeechError(speech.error)}
           voiceReview={voiceReview}
+          lastAnswerFeedback={lastAnswerFeedback}
           onSubmit={handleSubmit}
           onUserInputChange={(value) => dispatch({ type: 'SET_USER_INPUT', payload: value })}
           onTogglePracticeMode={handleTogglePracticeMode}
@@ -391,6 +427,7 @@ const App: React.FC<AppProps> = ({ initialVocab: initialVocabProp, initialLevels
         <VictoryScreen
           score={score}
           correctAnswers={correctAnswers}
+          learningSummary={buildLearningSummary(progress, Date.now())}
           onStartGame={startGame}
         />
       );

--- a/web/src/game/gameReducer.test.ts
+++ b/web/src/game/gameReducer.test.ts
@@ -1,4 +1,5 @@
 import { Level } from '../data/levels';
+import type { AnswerFeedback, LearningProgressState } from '../learning/progress';
 import { createInitialState, gameReducer } from './gameReducer';
 
 const levels: Level[] = [
@@ -29,11 +30,38 @@ describe('gameReducer', () => {
     expect(state.gameState).toBe('menu');
     expect(state.levels).toBe(levels);
     expect(state.recognitionLang).toBe('en-GB');
+    expect(state.progress).toEqual({});
+    expect(state.lastAnswerFeedback).toBeNull();
   });
 
   it('starts a new game from the first level and resets run progress', () => {
+    const progress: LearningProgressState = {
+      apple: {
+        wordId: 'apple',
+        word: 'apple',
+        attempts: 1,
+        correct: 1,
+        misses: 0,
+        streak: 1,
+        mastery: 1,
+        lastPracticedAt: 1,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: 2,
+      },
+    };
+    const feedback: AnswerFeedback = {
+      word: 'apple',
+      submitted: 'apple',
+      isCorrect: true,
+      mode: 'spelling',
+      mastery: 1,
+      nextReviewLabel: '約 1 天後',
+    };
     const state = {
       ...createInitialState({ levels, recognitionLang: 'en-US' }),
+      progress,
+      lastAnswerFeedback: feedback,
       currentLevel: 1,
       score: 120,
       enemyLives: 1,
@@ -56,6 +84,67 @@ describe('gameReducer', () => {
       skippedWords: 0,
       combo: 0,
       message: '',
+      progress,
+      lastAnswerFeedback: null,
+    });
+  });
+
+  it('stores loaded learning progress', () => {
+    const progress: LearningProgressState = {
+      apple: {
+        wordId: 'apple',
+        word: 'apple',
+        attempts: 1,
+        correct: 0,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: 1,
+        lastMissedAt: 1,
+        lastMode: 'voice',
+        dueAt: 1,
+      },
+    };
+
+    expect(gameReducer(createInitialState({ levels }), { type: 'SET_PROGRESS', payload: progress }).progress).toBe(progress);
+  });
+
+  it('stores and clears answer feedback', () => {
+    const feedback: AnswerFeedback = {
+      word: 'apple',
+      submitted: 'apl',
+      isCorrect: false,
+      mode: 'spelling',
+      mastery: 0,
+      nextReviewLabel: '現在複習',
+    };
+    const withFeedback = gameReducer(createInitialState({ levels }), {
+      type: 'SET_LAST_ANSWER_FEEDBACK',
+      payload: feedback,
+    });
+
+    expect(withFeedback.lastAnswerFeedback).toBe(feedback);
+    expect(gameReducer(withFeedback, { type: 'SET_LAST_ANSWER_FEEDBACK', payload: null }).lastAnswerFeedback).toBeNull();
+  });
+
+  it('clears answer feedback when selecting a new word', () => {
+    const state = {
+      ...createInitialState({ levels }),
+      lastAnswerFeedback: {
+        word: 'apple',
+        submitted: 'apl',
+        isCorrect: false,
+        mode: 'spelling',
+        mastery: 0,
+        nextReviewLabel: '現在複習',
+      } as AnswerFeedback,
+      userInput: 'apl',
+    };
+
+    expect(gameReducer(state, { type: 'SELECT_NEW_WORD', payload: null })).toMatchObject({
+      currentWord: null,
+      userInput: '',
+      lastAnswerFeedback: null,
     });
   });
 

--- a/web/src/game/gameReducer.ts
+++ b/web/src/game/gameReducer.ts
@@ -1,5 +1,6 @@
 import type { VocabItem } from '../types/vocab';
 import { defaultLevels, type Level } from '../data/levels';
+import type { AnswerFeedback, LearningProgressState } from '../learning/progress';
 
 export type GameState = 'menu' | 'playing' | 'victory' | 'vocab_management';
 
@@ -23,6 +24,8 @@ export interface AppState {
   showHint: boolean;
   isBossShaking: boolean;
   recognitionLang: string;
+  progress: LearningProgressState;
+  lastAnswerFeedback: AnswerFeedback | null;
 }
 
 export type AppAction =
@@ -41,6 +44,8 @@ export type AppAction =
   | { type: 'SET_PRACTICE_MODE'; payload: AppState['practiceMode'] }
   | { type: 'SET_SHOW_HINT'; payload: boolean }
   | { type: 'SET_RECOGNITION_LANG'; payload: string }
+  | { type: 'SET_PROGRESS'; payload: LearningProgressState }
+  | { type: 'SET_LAST_ANSWER_FEEDBACK'; payload: AnswerFeedback | null }
   | { type: 'SKIP_WORD' }
   | { type: 'SET_COMBO'; payload: number }
   | { type: 'RESET_EFFECTS' };
@@ -51,11 +56,13 @@ export const SKIP_PENALTY = 5;
 interface InitialStateOptions {
   levels?: Level[];
   recognitionLang?: string;
+  progress?: LearningProgressState;
 }
 
 export function createInitialState({
   levels = defaultLevels,
   recognitionLang = 'en-US',
+  progress = {},
 }: InitialStateOptions = {}): AppState {
   return {
     vocab: [],
@@ -77,6 +84,8 @@ export function createInitialState({
     showHint: false,
     isBossShaking: false,
     recognitionLang,
+    progress,
+    lastAnswerFeedback: null,
   };
 }
 
@@ -99,6 +108,7 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
         skippedWords: 0,
         combo: 0,
         message: '',
+        lastAnswerFeedback: null,
       };
     case 'SET_GAME_STATE':
       return {
@@ -107,7 +117,7 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
         message: action.payload === 'menu' ? '請先到字彙管理新增單字!' : '',
       };
     case 'SELECT_NEW_WORD':
-      return { ...state, currentWord: action.payload, userInput: '' };
+      return { ...state, currentWord: action.payload, userInput: '', lastAnswerFeedback: null };
     case 'HANDLE_CORRECT_ANSWER': {
       const { points, damage } = action.payload;
       const newEnemyLives = state.enemyLives - damage;
@@ -173,6 +183,10 @@ export function gameReducer(state: AppState, action: AppAction): AppState {
       return { ...state, showHint: action.payload };
     case 'SET_RECOGNITION_LANG':
       return { ...state, recognitionLang: action.payload };
+    case 'SET_PROGRESS':
+      return { ...state, progress: action.payload };
+    case 'SET_LAST_ANSWER_FEEDBACK':
+      return { ...state, lastAnswerFeedback: action.payload };
     case 'SKIP_WORD':
       return {
         ...state,

--- a/web/src/learning/progress.test.ts
+++ b/web/src/learning/progress.test.ts
@@ -1,0 +1,233 @@
+import type { VocabItem } from '../types/vocab';
+import {
+  buildLearningSummary,
+  createAnswerFeedback,
+  getTopReviewCandidates,
+  rankWordsForReview,
+  recordPracticeAttempt,
+  type LearningProgressState,
+} from './progress';
+
+const word = (id: string, value = id): VocabItem => ({
+  id,
+  word: value,
+  difficulty: 1,
+  enabled: true,
+  imageName: value,
+  size: 0,
+  type: '',
+});
+
+describe('learning progress', () => {
+  it('records a first correct spelling attempt', () => {
+    const now = 1_700_000_000_000;
+
+    const progress = recordPracticeAttempt({}, word('apple'), {
+      isCorrect: true,
+      mode: 'spelling',
+      now,
+    });
+
+    expect(progress.apple).toMatchObject({
+      wordId: 'apple',
+      word: 'apple',
+      attempts: 1,
+      correct: 1,
+      misses: 0,
+      streak: 1,
+      mastery: 1,
+      lastPracticedAt: now,
+      lastMissedAt: null,
+      lastMode: 'spelling',
+    });
+    expect(progress.apple.dueAt).toBeGreaterThan(now);
+  });
+
+  it('records an incorrect voice attempt as due immediately', () => {
+    const now = 1_700_000_000_000;
+
+    const progress = recordPracticeAttempt({}, word('apple'), {
+      isCorrect: false,
+      mode: 'voice',
+      now,
+    });
+
+    expect(progress.apple).toMatchObject({
+      attempts: 1,
+      correct: 0,
+      misses: 1,
+      streak: 0,
+      mastery: 0,
+      lastPracticedAt: now,
+      lastMissedAt: now,
+      lastMode: 'voice',
+      dueAt: now,
+    });
+  });
+
+  it('caps mastery at three after consecutive correct attempts', () => {
+    const apple = word('apple');
+    const first = recordPracticeAttempt({}, apple, { isCorrect: true, mode: 'spelling', now: 1 });
+    const second = recordPracticeAttempt(first, apple, { isCorrect: true, mode: 'spelling', now: 2 });
+    const third = recordPracticeAttempt(second, apple, { isCorrect: true, mode: 'spelling', now: 3 });
+    const fourth = recordPracticeAttempt(third, apple, { isCorrect: true, mode: 'spelling', now: 4 });
+
+    expect(fourth.apple.mastery).toBe(3);
+    expect(fourth.apple.streak).toBe(4);
+  });
+
+  it('ranks due lower-mastery words ahead of stable words', () => {
+    const now = 1_700_000_000_000;
+    const words = [word('stable'), word('due'), word('new')];
+    const progress: LearningProgressState = {
+      stable: {
+        wordId: 'stable',
+        word: 'stable',
+        attempts: 5,
+        correct: 5,
+        misses: 0,
+        streak: 5,
+        mastery: 3,
+        lastPracticedAt: now - 1_000,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: now + 7 * 24 * 60 * 60 * 1000,
+      },
+      due: {
+        wordId: 'due',
+        word: 'due',
+        attempts: 2,
+        correct: 1,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: now - 1_000,
+        lastMissedAt: now - 1_000,
+        lastMode: 'voice',
+        dueAt: now,
+      },
+    };
+
+    expect(rankWordsForReview(words, progress, now).map((item) => item.word)).toEqual([
+      'due',
+      'new',
+      'stable',
+    ]);
+  });
+
+  it('returns only the top review candidates for random selection', () => {
+    const now = 1_700_000_000_000;
+    const words = [word('stable'), word('due-a'), word('due-b')];
+    const progress: LearningProgressState = {
+      stable: {
+        wordId: 'stable',
+        word: 'stable',
+        attempts: 3,
+        correct: 3,
+        misses: 0,
+        streak: 3,
+        mastery: 3,
+        lastPracticedAt: now - 1_000,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: now + 1_000,
+      },
+      'due-a': {
+        wordId: 'due-a',
+        word: 'due-a',
+        attempts: 1,
+        correct: 0,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: now - 1_000,
+        lastMissedAt: now - 1_000,
+        lastMode: 'voice',
+        dueAt: now,
+      },
+      'due-b': {
+        wordId: 'due-b',
+        word: 'due-b',
+        attempts: 2,
+        correct: 1,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: now - 1_000,
+        lastMissedAt: now - 1_000,
+        lastMode: 'spelling',
+        dueAt: now,
+      },
+    };
+
+    expect(getTopReviewCandidates(words, progress, now).map((item) => item.word)).toEqual([
+      'due-a',
+      'due-b',
+    ]);
+  });
+
+  it('builds a learning summary from progress state', () => {
+    const now = 1_700_000_000_000;
+    const progress: LearningProgressState = {
+      apple: {
+        wordId: 'apple',
+        word: 'apple',
+        attempts: 3,
+        correct: 3,
+        misses: 0,
+        streak: 3,
+        mastery: 3,
+        lastPracticedAt: now - 1,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: now + 1_000,
+      },
+      sword: {
+        wordId: 'sword',
+        word: 'sword',
+        attempts: 1,
+        correct: 0,
+        misses: 1,
+        streak: 0,
+        mastery: 0,
+        lastPracticedAt: now - 1,
+        lastMissedAt: now - 1,
+        lastMode: 'voice',
+        dueAt: now,
+      },
+    };
+
+    expect(buildLearningSummary(progress, now)).toEqual({
+      practicedWords: 2,
+      masteredWords: 1,
+      dueWords: 1,
+    });
+  });
+
+  it('creates actionable answer feedback', () => {
+    const now = 1_700_000_000_000;
+    const progress = recordPracticeAttempt({}, word('apple'), {
+      isCorrect: false,
+      mode: 'spelling',
+      now,
+    });
+
+    expect(
+      createAnswerFeedback({
+        word: word('apple'),
+        submitted: 'apl',
+        isCorrect: false,
+        mode: 'spelling',
+        progress: progress.apple,
+        now,
+      }),
+    ).toEqual({
+      word: 'apple',
+      submitted: 'apl',
+      isCorrect: false,
+      mode: 'spelling',
+      mastery: 0,
+      nextReviewLabel: '現在複習',
+    });
+  });
+});

--- a/web/src/learning/progress.ts
+++ b/web/src/learning/progress.ts
@@ -1,0 +1,220 @@
+import type { VocabItem } from '../types/vocab';
+
+export type PracticeMode = 'voice' | 'spelling';
+export type MasteryLevel = 0 | 1 | 2 | 3;
+
+export type WordProgress = {
+  wordId: string;
+  word: string;
+  attempts: number;
+  correct: number;
+  misses: number;
+  streak: number;
+  mastery: MasteryLevel;
+  lastPracticedAt: number | null;
+  lastMissedAt: number | null;
+  lastMode: PracticeMode | null;
+  dueAt: number;
+};
+
+export type LearningProgressState = Record<string, WordProgress>;
+
+export type PracticeAttempt = {
+  isCorrect: boolean;
+  mode: PracticeMode;
+  now: number;
+};
+
+export type AnswerFeedback = {
+  word: string;
+  submitted: string;
+  isCorrect: boolean;
+  mode: PracticeMode;
+  mastery: MasteryLevel;
+  nextReviewLabel: string;
+};
+
+export type LearningSummary = {
+  practicedWords: number;
+  masteredWords: number;
+  dueWords: number;
+};
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const REVIEW_DELAYS_BY_MASTERY: Record<MasteryLevel, number> = {
+  0: HOUR_MS,
+  1: DAY_MS,
+  2: 3 * DAY_MS,
+  3: 7 * DAY_MS,
+};
+
+function createEmptyWordProgress(word: VocabItem): WordProgress {
+  return {
+    wordId: word.id,
+    word: word.word,
+    attempts: 0,
+    correct: 0,
+    misses: 0,
+    streak: 0,
+    mastery: 0,
+    lastPracticedAt: null,
+    lastMissedAt: null,
+    lastMode: null,
+    dueAt: 0,
+  };
+}
+
+function masteryFromStreak(streak: number): MasteryLevel {
+  return Math.min(3, Math.max(0, streak)) as MasteryLevel;
+}
+
+function getNextDueAt(mastery: MasteryLevel, now: number): number {
+  return now + REVIEW_DELAYS_BY_MASTERY[mastery];
+}
+
+export function recordPracticeAttempt(
+  progress: LearningProgressState,
+  word: VocabItem,
+  attempt: PracticeAttempt,
+): LearningProgressState {
+  const previous = progress[word.id] ?? createEmptyWordProgress(word);
+  const streak = attempt.isCorrect ? previous.streak + 1 : 0;
+  const mastery = attempt.isCorrect ? masteryFromStreak(streak) : 0;
+
+  const nextProgress: WordProgress = {
+    ...previous,
+    wordId: word.id,
+    word: word.word,
+    attempts: previous.attempts + 1,
+    correct: previous.correct + (attempt.isCorrect ? 1 : 0),
+    misses: previous.misses + (attempt.isCorrect ? 0 : 1),
+    streak,
+    mastery,
+    lastPracticedAt: attempt.now,
+    lastMissedAt: attempt.isCorrect ? previous.lastMissedAt : attempt.now,
+    lastMode: attempt.mode,
+    dueAt: attempt.isCorrect ? getNextDueAt(mastery, attempt.now) : attempt.now,
+  };
+
+  return {
+    ...progress,
+    [word.id]: nextProgress,
+  };
+}
+
+type ReviewRank = {
+  due: number;
+  mastery: number;
+  misses: number;
+  practiced: number;
+};
+
+function getReviewRank(word: VocabItem, progress: LearningProgressState, now: number): ReviewRank {
+  const wordProgress = progress[word.id];
+
+  if (!wordProgress) {
+    return {
+      due: 1,
+      mastery: 0,
+      misses: 0,
+      practiced: 0,
+    };
+  }
+
+  return {
+    due: wordProgress.dueAt <= now ? 0 : 1,
+    mastery: wordProgress.mastery,
+    misses: -wordProgress.misses,
+    practiced: 1,
+  };
+}
+
+export function rankWordsForReview(
+  words: VocabItem[],
+  progress: LearningProgressState,
+  now: number,
+): VocabItem[] {
+  return [...words].sort((left, right) => {
+    const leftRank = getReviewRank(left, progress, now);
+    const rightRank = getReviewRank(right, progress, now);
+
+    return leftRank.due - rightRank.due
+      || leftRank.mastery - rightRank.mastery
+      || leftRank.misses - rightRank.misses
+      || leftRank.practiced - rightRank.practiced;
+  });
+}
+
+function isSameReviewRank(left: ReviewRank, right: ReviewRank): boolean {
+  return left.due === right.due
+    && left.mastery === right.mastery
+    && left.misses === right.misses
+    && left.practiced === right.practiced;
+}
+
+export function getTopReviewCandidates(
+  words: VocabItem[],
+  progress: LearningProgressState,
+  now: number,
+): VocabItem[] {
+  const rankedWords = rankWordsForReview(words, progress, now);
+  const topWord = rankedWords[0];
+  if (!topWord) {
+    return [];
+  }
+
+  const topRank = getReviewRank(topWord, progress, now);
+  return rankedWords.filter((word) => isSameReviewRank(getReviewRank(word, progress, now), topRank));
+}
+
+export function buildLearningSummary(progress: LearningProgressState, now: number): LearningSummary {
+  const items = Object.values(progress).filter((item) => item.attempts > 0);
+
+  return {
+    practicedWords: items.length,
+    masteredWords: items.filter((item) => item.mastery >= 3).length,
+    dueWords: items.filter((item) => item.dueAt <= now).length,
+  };
+}
+
+function getNextReviewLabel(dueAt: number, now: number): string {
+  if (dueAt <= now) {
+    return '現在複習';
+  }
+
+  const diff = dueAt - now;
+  if (diff <= HOUR_MS) {
+    return '約 1 小時後';
+  }
+  if (diff <= DAY_MS) {
+    return '約 1 天後';
+  }
+
+  return `約 ${Math.ceil(diff / DAY_MS)} 天後`;
+}
+
+export function createAnswerFeedback({
+  word,
+  submitted,
+  isCorrect,
+  mode,
+  progress,
+  now,
+}: {
+  word: VocabItem;
+  submitted: string;
+  isCorrect: boolean;
+  mode: PracticeMode;
+  progress: WordProgress;
+  now: number;
+}): AnswerFeedback {
+  return {
+    word: word.word,
+    submitted,
+    isCorrect,
+    mode,
+    mastery: progress.mastery,
+    nextReviewLabel: getNextReviewLabel(progress.dueAt, now),
+  };
+}

--- a/web/src/persistence/progressStorage.test.ts
+++ b/web/src/persistence/progressStorage.test.ts
@@ -1,0 +1,68 @@
+import type { LearningProgressState } from '../learning/progress';
+import {
+  STORAGE_KEY_PROGRESS,
+  loadProgressFromStorage,
+  saveProgressToStorage,
+} from './progressStorage';
+import { STORAGE_KEY_VOCAB } from './vocabStorage';
+
+describe('progressStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns empty progress when storage is missing', () => {
+    expect(loadProgressFromStorage()).toEqual({});
+  });
+
+  it('returns empty progress when stored JSON is invalid', () => {
+    localStorage.setItem(STORAGE_KEY_PROGRESS, '{bad-json');
+
+    expect(loadProgressFromStorage()).toEqual({});
+  });
+
+  it('returns empty progress when stored progress has an unexpected shape', () => {
+    localStorage.setItem(STORAGE_KEY_PROGRESS, '[]');
+
+    expect(loadProgressFromStorage()).toEqual({});
+
+    localStorage.setItem(STORAGE_KEY_PROGRESS, JSON.stringify({
+      apple: {
+        word: 'apple',
+      },
+    }));
+
+    expect(loadProgressFromStorage()).toEqual({});
+  });
+
+  it('saves and loads progress from its own storage key', () => {
+    const progress: LearningProgressState = {
+      apple: {
+        wordId: 'apple',
+        word: 'apple',
+        attempts: 1,
+        correct: 1,
+        misses: 0,
+        streak: 1,
+        mastery: 1,
+        lastPracticedAt: 1_700_000_000_000,
+        lastMissedAt: null,
+        lastMode: 'spelling',
+        dueAt: 1_700_086_400_000,
+      },
+    };
+
+    saveProgressToStorage(progress);
+
+    expect(localStorage.getItem(STORAGE_KEY_PROGRESS)).toBe(JSON.stringify(progress));
+    expect(loadProgressFromStorage()).toEqual(progress);
+  });
+
+  it('does not overwrite vocabulary storage when saving progress', () => {
+    localStorage.setItem(STORAGE_KEY_VOCAB, '[{"word":"apple"}]');
+
+    saveProgressToStorage({});
+
+    expect(localStorage.getItem(STORAGE_KEY_VOCAB)).toBe('[{"word":"apple"}]');
+  });
+});

--- a/web/src/persistence/progressStorage.ts
+++ b/web/src/persistence/progressStorage.ts
@@ -1,0 +1,58 @@
+import type { LearningProgressState, WordProgress } from '../learning/progress';
+
+export const STORAGE_KEY_PROGRESS = 'echoquest_progress_v1';
+
+const VALID_MASTERY_LEVELS = new Set([0, 1, 2, 3]);
+const VALID_PRACTICE_MODES = new Set(['voice', 'spelling']);
+
+function isNullableNumber(value: unknown): boolean {
+  return value === null || typeof value === 'number';
+}
+
+function isWordProgress(value: unknown): value is WordProgress {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const hasValidLastMode = candidate.lastMode === null
+    || (typeof candidate.lastMode === 'string' && VALID_PRACTICE_MODES.has(candidate.lastMode));
+
+  return typeof candidate.wordId === 'string'
+    && typeof candidate.word === 'string'
+    && typeof candidate.attempts === 'number'
+    && typeof candidate.correct === 'number'
+    && typeof candidate.misses === 'number'
+    && typeof candidate.streak === 'number'
+    && typeof candidate.mastery === 'number'
+    && VALID_MASTERY_LEVELS.has(candidate.mastery)
+    && isNullableNumber(candidate.lastPracticedAt)
+    && isNullableNumber(candidate.lastMissedAt)
+    && hasValidLastMode
+    && typeof candidate.dueAt === 'number';
+}
+
+export function loadProgressFromStorage(): LearningProgressState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_PROGRESS);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const entries = Object.entries(parsed);
+    if (!entries.every(([, value]) => isWordProgress(value))) {
+      return {};
+    }
+
+    return parsed as LearningProgressState;
+  } catch {
+    return {};
+  }
+}
+
+export function saveProgressToStorage(progress: LearningProgressState): void {
+  localStorage.setItem(STORAGE_KEY_PROGRESS, JSON.stringify(progress));
+}

--- a/web/src/screens/GameScreen.tsx
+++ b/web/src/screens/GameScreen.tsx
@@ -4,6 +4,7 @@ import { IconButton, Panel, QuestButton, ScreenShell, StatBadge } from '../compo
 import { LanguageSelector } from '../components/LanguageSelector';
 import type { Level } from '../data/levels';
 import type { AppState } from '../game/gameReducer';
+import type { AnswerFeedback } from '../learning/progress';
 import type { VocabItem } from '../types/vocab';
 
 type VoiceReviewResult = {
@@ -41,6 +42,7 @@ type GameScreenProps = {
   speechErrorMessage: string | null;
   canRetrySpeechError: boolean;
   voiceReview: VoiceReviewResult | null;
+  lastAnswerFeedback: AnswerFeedback | null;
   onSubmit: (submittedText: string) => void;
   onUserInputChange: (value: string) => void;
   onTogglePracticeMode: () => void;
@@ -73,6 +75,7 @@ export function GameScreen({
   speechErrorMessage,
   canRetrySpeechError,
   voiceReview,
+  lastAnswerFeedback,
   onSubmit,
   onUserInputChange,
   onTogglePracticeMode,
@@ -194,6 +197,19 @@ export function GameScreen({
                         確認送出
                       </QuestButton>
                     </div>
+                  </div>
+                )}
+
+                {lastAnswerFeedback && (
+                  <div className="eq-voice-review w-full" role="status" aria-live="polite">
+                    <p className="text-lg font-extrabold text-[color:var(--eq-river)]">
+                      {lastAnswerFeedback.isCorrect
+                        ? `答對了：${lastAnswerFeedback.word}`
+                        : `你輸入「${lastAnswerFeedback.submitted}」，目標是 ${lastAnswerFeedback.word}`}
+                    </p>
+                    <p className="text-sm font-bold text-[color:var(--eq-muted)]">
+                      {`掌握度 ${lastAnswerFeedback.mastery}/3 · 下次複習：${lastAnswerFeedback.nextReviewLabel}`}
+                    </p>
                   </div>
                 )}
 

--- a/web/src/screens/VictoryScreen.tsx
+++ b/web/src/screens/VictoryScreen.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import { Trophy } from 'lucide-react';
 import { Panel, QuestButton, ScreenShell } from '../components/QuestFrame';
+import type { LearningSummary } from '../learning/progress';
 
 type VictoryScreenProps = {
   score: number;
   correctAnswers: number;
+  learningSummary: LearningSummary;
   onStartGame: () => void;
 };
 
-export function VictoryScreen({ score, correctAnswers, onStartGame }: VictoryScreenProps) {
+export function VictoryScreen({ score, correctAnswers, learningSummary, onStartGame }: VictoryScreenProps) {
   return (
     <ScreenShell screen="victory" label="EchoQuest 勝利結果" className="grid place-items-center">
       <Panel className="w-full max-w-md p-8 text-center">
         <Trophy className="w-20 h-20 text-[color:var(--eq-sun)] mx-auto mb-4" />
         <h1 className="eq-display text-4xl font-extrabold text-[color:var(--eq-ink)] mb-4">勝利！</h1>
         <p className="text-2xl font-extrabold text-[color:var(--eq-river)] mb-2">最終分數: {score}</p>
-        <p className="text-lg text-[color:var(--eq-muted)] mb-6">答對 {correctAnswers} 個單字</p>
+        <p className="text-lg text-[color:var(--eq-muted)] mb-4">答對 {correctAnswers} 個單字</p>
+        <div className="mb-6 grid gap-2 text-left text-sm font-bold text-[color:var(--eq-muted)]">
+          <p>{`練習單字: ${learningSummary.practicedWords}`}</p>
+          <p>{`精熟單字: ${learningSummary.masteredWords}`}</p>
+          <p>{`待複習: ${learningSummary.dueWords}`}</p>
+        </div>
         <QuestButton onClick={onStartGame} className="w-full" variant="gold" icon={<Trophy className="w-5 h-5" />}>
           再玩一次
         </QuestButton>


### PR DESCRIPTION
## Summary
- Add a per-word learning progress model for attempts, misses, streaks, mastery, due review timing, and end-of-run summary metrics.
- Persist progress separately from vocabulary storage and harden storage loading against invalid shapes.
- Use due/weak progress to prioritize the next challenge and show actionable answer feedback in the game UI.

## Tests
- `npm test -- --runInBand`
- `npm run build`

Closes #59