### PR TITLE
feat: finish vocabulary accessibility workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ EchoQuest is a local-first English learning adventure game for a family audience
 
 Progress is stored in browser `localStorage`, including the exact active mission, vocabulary, learner profile, recognition language, and per-word mastery.
 
+## Family Vocabulary Library
+
+Open the library with the settings button to search, filter, edit, enable, or remove words. Image and folder imports skip duplicate words case-insensitively and report added, skipped, and failed files inline without interrupting play.
+
 ## Voice Input
 
 Voice is implemented as a safe optional input path:

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -321,7 +321,7 @@
     }
     .eq-letter-tile:disabled { opacity: .32; cursor: not-allowed; }
     .eq-typing-game { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 8px; }
-    .eq-typing-game input, .eq-select {
+    .eq-typing-game input, .eq-input, .eq-select {
       min-height: 42px;
       min-width: 0;
       border: 1px solid #89b7b5;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -161,7 +161,7 @@ describe('EchoQuest family relay rescue', () => {
     renderGame();
     fireEvent.click(screen.getByRole('button', { name: '繼續救援' }));
 
-    fireEvent.change(screen.getByLabelText('Type answer'), { target: { value: 'apple' } });
+    fireEvent.change(screen.getByLabelText('輸入答案'), { target: { value: 'apple' } });
     fireEvent.click(screen.getByRole('button', { name: '施放路徑魔法' }));
 
     expect(screen.getByTestId('relay-world')).toHaveAttribute('data-event', 'build');
@@ -180,7 +180,7 @@ describe('EchoQuest family relay rescue', () => {
     renderGame();
     fireEvent.click(screen.getByRole('button', { name: '繼續救援' }));
 
-    const answer = screen.getByLabelText('Type answer');
+    const answer = screen.getByLabelText('輸入答案');
     const submit = screen.getByRole('button', { name: '施放路徑魔法' });
     fireEvent.change(answer, { target: { value: 'apple' } });
     fireEvent.click(submit);
@@ -221,11 +221,11 @@ describe('EchoQuest family relay rescue', () => {
     renderGame();
     fireEvent.click(screen.getByRole('button', { name: '繼續救援' }));
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'letter p' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '字母 p' })[0]);
     expect(screen.getByLabelText('拼字答案')).toHaveTextContent('點字母拼單字');
     expect(screen.getByText('下一個字母：A')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'letter a' }));
+    fireEvent.click(screen.getByRole('button', { name: '字母 a' }));
     expect(screen.getByLabelText('拼字答案')).toHaveTextContent('a');
     expect(screen.getByText('下一個字母：P')).toBeInTheDocument();
   });
@@ -239,7 +239,7 @@ describe('EchoQuest family relay rescue', () => {
     renderGame();
     fireEvent.click(screen.getByRole('button', { name: '繼續救援' }));
 
-    fireEvent.change(screen.getByLabelText('Type answer'), { target: { value: 'apple' } });
+    fireEvent.change(screen.getByLabelText('輸入答案'), { target: { value: 'apple' } });
     fireEvent.click(screen.getByRole('button', { name: '魔法充能' }));
     for (const spell of ['火焰術', '守護盾', '治癒光']) {
       expect(screen.getByRole('button', { name: new RegExp(spell) })).toBeEnabled();
@@ -261,7 +261,7 @@ describe('EchoQuest family relay rescue', () => {
     fireEvent.click(screen.getByRole('button', { name: '繼續救援' }));
 
     for (const [word, spell] of [['apple', '火焰術'], ['ball', '守護盾'], ['apple', '治癒光']] as const) {
-      fireEvent.change(screen.getByLabelText('Type answer'), { target: { value: word } });
+      fireEvent.change(screen.getByLabelText('輸入答案'), { target: { value: word } });
       fireEvent.click(screen.getByRole('button', { name: '魔法充能' }));
       fireEvent.click(screen.getByRole('button', { name: new RegExp(spell) }));
     }
@@ -294,7 +294,16 @@ describe('EchoQuest family relay rescue', () => {
     renderGame();
 
     expect(screen.getByRole('alert')).toHaveTextContent('語音暫時不可用');
-    expect(screen.getByLabelText('Type answer')).toBeEnabled();
+    expect(screen.getByLabelText('輸入答案')).toBeEnabled();
+  });
+
+  it('opens the vocabulary library with one main landmark and one return command', () => {
+    renderGame();
+
+    fireEvent.click(screen.getByRole('button', { name: '開啟字庫' }));
+
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: '返回遊戲' })).toHaveLength(1);
   });
 
   it('fails gracefully when no vocabulary is enabled', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -365,14 +365,7 @@ export default function App({ initialVocab, initialLevels = defaultLevels }: App
   };
 
   if (screen === 'vocab_management') {
-    return (
-      <main className="eq-adventure eq-adventure--management">
-        <div className="eq-adventure-vocab">
-          <button type="button" className="eq-arcade-small-button" onClick={() => setScreen('play')}>回到救援</button>
-          <VocabManager vocab={vocab} onVocabChange={setVocab} onGoBack={() => setScreen('play')} />
-        </div>
-      </main>
-    );
+    return <VocabManager vocab={vocab} onVocabChange={setVocab} onGoBack={() => setScreen('play')} />;
   }
 
   const relayClass = `eq-relay eq-relay--${currentEvent?.kind ?? 'empty'} eq-relay--${profile}`;
@@ -382,7 +375,7 @@ export default function App({ initialVocab, initialLevels = defaultLevels }: App
   const runeProgress = currentWord ? selectedLetters.length / Math.max(1, currentWord.word.length) : 0;
 
   return (
-    <main className={relayClass} aria-label="EchoQuest family relay rescue">
+    <main className={relayClass} aria-label="EchoQuest 家庭接力救援">
       <header className="eq-relay-hud">
         <div className="eq-relay-mission">
           <span>森林接力救援</span>
@@ -465,7 +458,7 @@ export default function App({ initialVocab, initialLevels = defaultLevels }: App
                 </div>
                 <div className="eq-letter-bank" aria-label="字母選項">
                   {letterTiles.map((tile) => (
-                    <button key={tile.id} type="button" className="eq-letter-tile" onClick={() => selectLetter(tile.id)} disabled={tile.used} aria-label={`letter ${tile.letter}`}>
+                    <button key={tile.id} type="button" className="eq-letter-tile" onClick={() => selectLetter(tile.id)} disabled={tile.used} aria-label={`字母 ${tile.letter}`}>
                       {tile.letter}
                     </button>
                   ))}
@@ -478,7 +471,7 @@ export default function App({ initialVocab, initialLevels = defaultLevels }: App
 
             {profile === 'adult' && (
               <form className="eq-typing-game" onSubmit={(event) => { event.preventDefault(); submitAnswer(typedAnswer, 'spelling'); }}>
-                <input value={typedAnswer} onChange={(event) => setTypedAnswer(event.target.value)} autoComplete="off" aria-label="Type answer" />
+                <input value={typedAnswer} onChange={(event) => setTypedAnswer(event.target.value)} autoComplete="off" aria-label="輸入答案" />
                 <button type="submit" className="eq-arcade-primary">{submitLabel}</button>
               </form>
             )}

--- a/web/src/components/LanguageSelector.test.tsx
+++ b/web/src/components/LanguageSelector.test.tsx
@@ -15,7 +15,7 @@ describe('<LanguageSelector />', () => {
       />
     );
 
-    const selector = screen.getByRole('combobox', { name: /select recognition language/i });
+    const selector = screen.getByRole('combobox', { name: '選擇語音辨識語言' });
 
     expect(selector).toHaveValue('en-US');
     expect(screen.getByText('English (US)')).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('<LanguageSelector />', () => {
   it('renders the compact selector with the current language', () => {
     render(<LanguageSelector selectedLang="zh-TW" onLangChange={jest.fn()} />);
 
-    expect(screen.getByRole('combobox', { name: /select recognition language/i })).toHaveValue('zh-TW');
+    expect(screen.getByRole('combobox', { name: '選擇語音辨識語言' })).toHaveValue('zh-TW');
     expect(screen.getByText('English (UK)')).toBeInTheDocument();
   });
 });

--- a/web/src/components/LanguageSelector.tsx
+++ b/web/src/components/LanguageSelector.tsx
@@ -23,7 +23,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
     <select
       value={selectedLang}
       onChange={(e) => onLangChange(e.target.value)}
-      aria-label="Select recognition language"
+      aria-label="選擇語音辨識語言"
       className="eq-select"
     >
       {languages.map((lang) => (

--- a/web/src/components/VocabManager.test.tsx
+++ b/web/src/components/VocabManager.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { VocabManager, fileNameToWord, parseDifficultyFromPath } from './VocabManager';
+import { VocabManager, fileNameToWord, mergeImportedVocab, parseDifficultyFromPath } from './VocabManager';
 import type { VocabItem } from '../types/vocab';
 
 // Mock data for testing the component
@@ -62,6 +62,21 @@ describe('VocabManager utility functions', () => {
       expect(parseDifficultyFromPath('004-a/002-b/image.png')).toBe(4);
     });
   });
+
+  describe('mergeImportedVocab', () => {
+    it('skips duplicate words case-insensitively', () => {
+      const incoming: VocabItem[] = [
+        { ...mockVocab[0], id: '3', word: 'Apple' },
+        { ...mockVocab[0], id: '4', word: 'cherry', imageName: 'cherry.png' },
+      ];
+
+      expect(mergeImportedVocab(mockVocab, incoming)).toEqual({
+        vocab: [...mockVocab, incoming[1]],
+        added: 1,
+        skipped: 1,
+      });
+    });
+  });
 });
 
 describe('<VocabManager /> Component', () => {
@@ -83,13 +98,13 @@ describe('<VocabManager /> Component', () => {
 
   it('should render the list of vocabulary items', () => {
     expect(screen.getByRole('main', { name: 'EchoQuest 字彙庫' })).toHaveAttribute('data-screen', 'vocab-management');
-    expect(screen.getByText('apple')).toBeInTheDocument();
-    expect(screen.getByText('banana')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('apple')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('banana')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem').length).toBe(2);
   });
 
   it('should render bundled artwork previews when imageSrc is available', () => {
-    expect(screen.getByRole('img', { name: 'apple artwork' })).toHaveAttribute('src', 'assets/generated/word-apple.png');
+    expect(screen.getByRole('img', { name: 'apple 圖片' })).toHaveAttribute('src', 'assets/generated/word-apple.png');
   });
 
   it('should call onGoBack when the "返回遊戲" button is clicked', () => {
@@ -98,9 +113,7 @@ describe('<VocabManager /> Component', () => {
   });
 
   it('should call onVocabChange with the item removed when delete is clicked', () => {
-    // Get all delete buttons, and click the first one (for 'apple')
-    const deleteButtons = screen.getAllByRole('button', { name: '刪除' });
-    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: '刪除 apple' }));
 
     expect(mockOnVocabChange).toHaveBeenCalledTimes(1);
     // Expect the call to be with an array containing only the 'banana' item
@@ -108,9 +121,7 @@ describe('<VocabManager /> Component', () => {
   });
 
   it('should call onVocabChange with updated difficulty when changed', () => {
-    const difficultySelects = screen.getAllByRole('combobox');
-    // Change the difficulty of the first item ('apple') to 5
-    fireEvent.change(difficultySelects[0], { target: { value: '5' } });
+    fireEvent.change(screen.getByRole('combobox', { name: 'apple 難度' }), { target: { value: '5' } });
 
     expect(mockOnVocabChange).toHaveBeenCalledTimes(1);
     const expectedNewVocab = [...mockVocab];
@@ -119,13 +130,46 @@ describe('<VocabManager /> Component', () => {
   });
 
   it('should call onVocabChange with updated enabled status when checkbox is clicked', () => {
-    const checkboxes = screen.getAllByRole('checkbox');
-    // The first item 'apple' is enabled, so its checkbox is checked. Click it to disable.
-    fireEvent.click(checkboxes[0]);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'apple 啟用' }));
 
     expect(mockOnVocabChange).toHaveBeenCalledTimes(1);
     const expectedNewVocab = [...mockVocab];
     expectedNewVocab[0] = { ...expectedNewVocab[0], enabled: false };
     expect(mockOnVocabChange).toHaveBeenCalledWith(expectedNewVocab);
+  });
+
+  it('filters the vocabulary list by search text and enabled state', () => {
+    fireEvent.change(screen.getByRole('searchbox', { name: '搜尋單字' }), { target: { value: 'ban' } });
+    expect(screen.queryByText('apple')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('banana')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '搜尋單字' }), { target: { value: '' } });
+    fireEvent.change(screen.getByRole('combobox', { name: '顯示範圍' }), { target: { value: 'enabled' } });
+    expect(screen.getByDisplayValue('apple')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('banana')).not.toBeInTheDocument();
+  });
+
+  it('edits a word through a labelled text field', () => {
+    fireEvent.change(screen.getByRole('textbox', { name: 'apple 單字' }), { target: { value: 'apricot' } });
+
+    expect(mockOnVocabChange).toHaveBeenCalledWith([
+      { ...mockVocab[0], word: 'apricot' },
+      mockVocab[1],
+    ]);
+  });
+
+  it('shows import errors inline without a blocking alert', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    const invalidFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const fileInput = screen.getByLabelText('新增圖片');
+
+    fireEvent.change(fileInput, { target: { files: [invalidFile] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('新增 0 個');
+      expect(screen.getByRole('status')).toHaveTextContent('失敗 1 個');
+    });
+    expect(alertSpy).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 });

--- a/web/src/components/VocabManager.tsx
+++ b/web/src/components/VocabManager.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, FolderOpen, ImagePlus, Trash2 } from 'lucide-react';
 import { Panel, QuestButton, ScreenShell } from './QuestFrame';
 import type { VocabItem } from '../types/vocab';
@@ -27,9 +27,31 @@ export function parseDifficultyFromPath(path?: string): number | null {
   return null;
 }
 
+export function mergeImportedVocab(existing: VocabItem[], incoming: VocabItem[]) {
+  const seen = new Set(existing.map((item) => item.word.trim().toLowerCase()));
+  const addedItems: VocabItem[] = [];
+  let skipped = 0;
+
+  for (const item of incoming) {
+    const word = item.word.trim().toLowerCase();
+    if (!word || seen.has(word)) {
+      skipped += 1;
+      continue;
+    }
+    seen.add(word);
+    addedItems.push({ ...item, word });
+  }
+
+  return {
+    vocab: [...existing, ...addedItems],
+    added: addedItems.length,
+    skipped,
+  };
+}
+
 function DifficultyPips({ level }: { level: number }) {
   return (
-    <div className="flex items-center gap-1" title={`Difficulty ${level}`}>
+    <div className="flex items-center gap-1" title={`難度 ${level}`}>
       {Array.from({ length: 5 }).map((_, i) => (
         <div
           key={i}
@@ -50,7 +72,7 @@ function ImagePreview({ src, label }: { src?: string; label: string }) {
   return (
     <img
       src={src}
-      alt={`${label} artwork`}
+      alt={`${label} 圖片`}
       className="eq-preview"
     />
   );
@@ -64,11 +86,23 @@ interface VocabManagerProps {
 
 export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange, onGoBack }) => {
   const dirInputRef = useRef<HTMLInputElement | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [visibility, setVisibility] = useState<'all' | 'enabled' | 'disabled'>('all');
+  const [importSummary, setImportSummary] = useState<{ added: number; skipped: number; errors: string[] } | null>(null);
+
+  const visibleVocab = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return vocab.filter((item) => {
+      const matchesQuery = !query || item.word.toLowerCase().includes(query);
+      const matchesVisibility = visibility === 'all'
+        || (visibility === 'enabled' ? item.enabled : !item.enabled);
+      return matchesQuery && matchesVisibility;
+    });
+  }, [searchQuery, visibility, vocab]);
 
   useEffect(() => {
     if (dirInputRef.current) {
-      // @ts-ignore
-      dirInputRef.current.webkitdirectory = true;
+      dirInputRef.current.setAttribute('webkitdirectory', '');
     }
   }, []);
 
@@ -91,25 +125,24 @@ export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange
     const errors: string[] = [];
     for (const f of arr) {
       if (!f.type.startsWith("image/")) {
-        errors.push(`${f.name}: Not an image file`);
+        errors.push(`${f.name}：不是圖片檔案`);
         continue;
       }
       if (f.size > MAX_IMAGE_BYTES) {
-        errors.push(`${f.name}: File too large`);
+        errors.push(`${f.name}：檔案超過 1MB`);
         continue;
       }
       let dataUrl: string | undefined;
       try {
         dataUrl = await fileToDataUrl(f);
       } catch {
-        errors.push(`${f.name}: Failed to load`);
+        errors.push(`${f.name}：讀取失敗`);
         continue;
       }
-      const anyFile = f as any;
-      const relPath: string | undefined = directoryMode ? anyFile.webkitRelativePath : undefined;
+      const relPath = directoryMode ? f.webkitRelativePath : undefined;
       const word = fileNameToWord(f.name);
       if (!word) {
-        errors.push(`${f.name}: Could not derive word from filename`);
+        errors.push(`${f.name}：檔名中找不到英文單字`);
         continue;
       }
       const parsedLevel = parseDifficultyFromPath(relPath);
@@ -126,11 +159,10 @@ export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange
       };
       newItems.push(item);
     }
-    if (errors.length) {
-      alert(errors.join("\n"));
-    }
-    if (newItems.length) {
-      onVocabChange([...vocab, ...newItems]);
+    const merged = mergeImportedVocab(vocab, newItems);
+    setImportSummary({ added: merged.added, skipped: merged.skipped, errors });
+    if (merged.added > 0) {
+      onVocabChange(merged.vocab);
     }
   }
 
@@ -140,7 +172,7 @@ export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange
         <Panel className="p-5 sm:p-7">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-6">
             <div>
-              <p className="text-sm font-extrabold uppercase text-[color:var(--eq-muted)]">Inventory</p>
+              <p className="text-sm font-extrabold text-[color:var(--eq-muted)]">家庭字庫</p>
               <h1 className="eq-display text-3xl font-extrabold text-[color:var(--eq-ink)]">字彙管理</h1>
             </div>
             <QuestButton onClick={onGoBack} variant="quiet" icon={<ArrowLeft className="w-5 h-5" />}>
@@ -173,37 +205,87 @@ export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange
             </label>
           </div>
 
+          {importSummary && (
+            <div className="mb-5 rounded-md border border-[color:var(--eq-line)] bg-white p-3 text-sm text-[color:var(--eq-ink)]" role="status">
+              <strong>匯入完成：</strong>新增 {importSummary.added} 個、略過重複 {importSummary.skipped} 個、失敗 {importSummary.errors.length} 個。
+              {importSummary.errors.length > 0 && (
+                <ul className="mt-2 list-disc pl-5">
+                  {importSummary.errors.map((error, index) => <li key={`${error}-${index}`}>{error}</li>)}
+                </ul>
+              )}
+            </div>
+          )}
+
+          <div className="mb-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_180px]">
+            <label className="grid gap-1 text-sm font-bold text-[color:var(--eq-ink)]">
+              搜尋單字
+              <input
+                type="search"
+                className="eq-input"
+                aria-label="搜尋單字"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-bold text-[color:var(--eq-ink)]">
+              顯示範圍
+              <select className="eq-select" aria-label="顯示範圍" value={visibility} onChange={(event) => setVisibility(event.target.value as typeof visibility)}>
+                <option value="all">全部</option>
+                <option value="enabled">已啟用</option>
+                <option value="disabled">已停用</option>
+              </select>
+            </label>
+          </div>
+
           <div className="eq-vocab-list">
             <ul>
-              {vocab.map((v) => (
+              {visibleVocab.map((v) => (
                 <li key={v.id} className="eq-vocab-row">
                   <ImagePreview src={v.imageDataUrl ?? v.imageSrc} label={v.word} />
-                  <div className="min-w-0">
-                    <span className="font-extrabold text-[color:var(--eq-ink)]">{v.word}</span>
-                    <DifficultyPips level={v.difficulty} />
-                  </div>
-                  <div className="eq-vocab-actions flex flex-wrap items-center gap-3">
-                    <select
-                      className="eq-select"
-                      value={v.difficulty}
-                      onChange={(e) =>
-                        onVocabChange(vocab.map((i) => i.id === v.id ? { ...i, difficulty: Number(e.target.value) } : i))
-                      }
-                    >
-                      {[1, 2, 3, 4, 5].map(n => <option key={n} value={n}>{n}</option>)}
-                    </select>
+                  <label className="min-w-0 text-sm font-bold text-[color:var(--eq-ink)]">
+                    單字
                     <input
-                      type="checkbox"
-                      className="h-5 w-5 accent-[color:var(--eq-forest)]"
-                      checked={v.enabled}
-                      onChange={(e) =>
-                        onVocabChange(vocab.map((i) => i.id === v.id ? { ...i, enabled: e.target.checked } : i))
-                      }
+                      className="eq-input mt-1 w-full font-extrabold"
+                      aria-label={`${v.word} 單字`}
+                      value={v.word}
+                      onChange={(event) => {
+                        const word = event.target.value.toLowerCase().replace(/[^a-z]/g, '');
+                        onVocabChange(vocab.map((item) => item.id === v.id ? { ...item, word } : item));
+                      }}
                     />
+                    <DifficultyPips level={v.difficulty} />
+                  </label>
+                  <div className="eq-vocab-actions flex flex-wrap items-center gap-3">
+                    <label className="grid gap-1 text-sm font-bold text-[color:var(--eq-ink)]">
+                      難度
+                      <select
+                        className="eq-select"
+                        aria-label={`${v.word} 難度`}
+                        value={v.difficulty}
+                        onChange={(e) =>
+                          onVocabChange(vocab.map((i) => i.id === v.id ? { ...i, difficulty: Number(e.target.value) } : i))
+                        }
+                      >
+                        {[1, 2, 3, 4, 5].map(n => <option key={n} value={n}>{n}</option>)}
+                      </select>
+                    </label>
+                    <label className="flex items-center gap-2 text-sm font-bold text-[color:var(--eq-ink)]">
+                      <input
+                        type="checkbox"
+                        aria-label={`${v.word} 啟用`}
+                        className="h-5 w-5 accent-[color:var(--eq-forest)]"
+                        checked={v.enabled}
+                        onChange={(e) =>
+                          onVocabChange(vocab.map((i) => i.id === v.id ? { ...i, enabled: e.target.checked } : i))
+                        }
+                      />
+                      啟用
+                    </label>
                     <QuestButton
                       onClick={() => onVocabChange(vocab.filter(i => i.id !== v.id))}
                       variant="danger"
                       icon={<Trash2 className="w-4 h-4" />}
+                      aria-label={`刪除 ${v.word}`}
                     >
                       刪除
                     </QuestButton>
@@ -211,6 +293,7 @@ export const VocabManager: React.FC<VocabManagerProps> = ({ vocab, onVocabChange
                 </li>
               ))}
             </ul>
+            {visibleVocab.length === 0 && <p className="p-6 text-center text-[color:var(--eq-muted)]" role="status">找不到符合條件的單字。</p>}
           </div>
         </Panel>
       </div>

--- a/web/src/screens/GameScreen.tsx
+++ b/web/src/screens/GameScreen.tsx
@@ -125,14 +125,14 @@ export function GameScreen({
 
             <div className={`eq-enemy-figure ${feedbackPresentation.enemyClassName}`}>
               {level.imageSrc ? (
-                <img src={level.imageSrc} alt={`${level.name} artwork`} className="eq-enemy-artwork" />
+                <img src={level.imageSrc} alt={`${level.name} 圖片`} className="eq-enemy-artwork" />
               ) : (
                 <span aria-hidden="true">{level.imageEmoji}</span>
               )}
             </div>
 
             {level.type === 'boss' && (
-              <div className="flex justify-center items-center gap-2" aria-label="Boss health">
+              <div className="flex justify-center items-center gap-2" aria-label="首領生命值">
                 <Skull className="w-7 h-7 text-[color:var(--eq-rust)]" />
                 <div className="flex gap-1">
                   {[...Array(level.enemyLives ?? 0)].map((_, i) => (
@@ -147,7 +147,7 @@ export function GameScreen({
             )}
 
             {level.type === 'puzzle' && (
-              <div className="flex justify-center items-center gap-2 text-4xl" aria-label="Puzzle progress">
+              <div className="flex justify-center items-center gap-2 text-4xl" aria-label="謎題進度">
                 {[...Array(level.tools ? level.tools.length - collectedTools.length : 0)].map((_, i) => (
                   <span key={i}>🚪</span>
                 ))}
@@ -246,7 +246,7 @@ export function GameScreen({
                 )}
 
                 {usesImageChoice && challenge && (
-                  <div className="eq-choice-grid" aria-label="Picture choices">
+                  <div className="eq-choice-grid" aria-label="圖片選項">
                     {challenge.choices.map((choice) => {
                       const choiceImageSrc = choice.imageDataUrl ?? choice.imageSrc;
                       return (
@@ -337,7 +337,7 @@ export function GameScreen({
 
                 <div className="flex gap-3 items-center">
                   <IconButton
-                    aria-label="Show hint"
+                    aria-label="顯示提示"
                     onMouseDown={() => onShowHintChange(true)}
                     onMouseUp={() => onShowHintChange(false)}
                     onTouchStart={() => onShowHintChange(true)}
@@ -345,7 +345,7 @@ export function GameScreen({
                   >
                     <HelpCircle className="w-6 h-6" />
                   </IconButton>
-                  <IconButton aria-label="Skip word" onClick={onSkip} variant="danger">
+                  <IconButton aria-label="跳過單字" onClick={onSkip} variant="danger">
                     <SkipForward className="w-6 h-6" />
                   </IconButton>
                 </div>

--- a/web/src/screens/MenuScreen.tsx
+++ b/web/src/screens/MenuScreen.tsx
@@ -44,7 +44,7 @@ export function MenuScreen({
               <select
                 value={learnerProfile}
                 onChange={(event) => onLearnerProfileChange(event.target.value as LearnerProfile)}
-                aria-label="Select learner profile"
+                aria-label="選擇學習者模式"
                 className="eq-select flex-1"
               >
                 {learnerProfileOptions.map((option) => (


### PR DESCRIPTION
Closes #61
Closes #62

## Summary
- add word search, enabled-state filtering, inline editing, and intentional duplicate skipping
- replace blocking import alerts with localized added/skipped/failed summaries
- add visible and accessible labels, localized control names, and a single valid main landmark
- document the family vocabulary workflow

## Verification
- `npm test -- --runInBand`: 17 suites, 148 tests passed
- `npm run build`: passed
- Chrome CDP production live review at 818px and 390px: search/filter controls fit, one main/return action, no horizontal overflow, no runtime errors
- `git diff --check` and `git merge-tree origin/main HEAD`: clean